### PR TITLE
Rename put option no-stat-caching

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -548,7 +548,7 @@ fn put_main(args: Vec<String>) -> Result<(), failure::Error> {
     );
     opts.optflag(
         "",
-        "no-stat-cache",
+        "no-stat-caching",
         "Do not use stat caching to skip sending directories to the server.",
     );
     opts.optflag(


### PR DESCRIPTION
Change the name of the `bupstash put` option `no-stat-cache` to `no-stat-caching`.