### PR TITLE
std::env::current_exe() sometimes fails on OpenBSD

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -320,7 +320,12 @@ fn cli_to_serve_process(
                     args
                 } else {
                     vec![
-                        std::env::current_exe()?.to_string_lossy().to_string(),
+                        if cfg!(target_os = "openbsd") {
+                            let args: Vec<String> = std::env::args().collect();
+                            args[0].clone()
+                        } else {
+                            std::env::current_exe()?.to_string_lossy().to_string()
+                        },
                         "serve".to_owned(),
                         repo,
                     ]


### PR DESCRIPTION
OpenBSD does not offer a standard way to retrieve the path of the
running executable. This means that env::current_exe() cannot return
anything useful when bupstash is resolved through $PATH resulting in a
hard fail (https://github.com/rust-lang/rust/issues/60560):

```
$ bupstash version
bupstash-0.6.3
$ export BUPSTASH_REPOSITORY=/tmp/xxx
$ rm -rf $BUPSTASH_REPOSITORY; bupstash init; echo $?
bupstash init: no current exe available (short)
1
$ rm -rf $BUPSTASH_REPOSITORY; ./bupstash init; echo $?
0
```
Instead use progname via std::env::args() on OpenBSD:

```
$ export BUPSTASH_REPOSITORY=/tmp/xxx
$ rm -rf $BUPSTASH_REPOSITORY; bupstash init; echo $?
0
$ rm -rf $BUPSTASH_REPOSITORY; ./bupstash init; echo $?
0
```