### PR TITLE
Replace zstd remnants

### DIFF
--- a/doc/man/bupstash-repository.7.md
+++ b/doc/man/bupstash-repository.7.md
@@ -203,7 +203,7 @@ DATA[...] || 0x00
 
 Valid compression flags are:
 
-- 1 << 0 == zstd compression.
+- 1 << 0 == lz4 compression.
 
 ### Hash tree node chunk
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -52,7 +52,7 @@ pub fn decompress(mut data: Vec<u8>) -> Result<Vec<u8>, anyhow::Error> {
         footer if footer == COMPRESS_FOOTER_LZ4_COMPRESSED => {
             data.pop();
             if data.len() < 4 {
-                anyhow::bail!("data corrupt - zstd data footer missing decompressed size");
+                anyhow::bail!("data corrupt - lz4 data footer missing decompressed size");
             }
             let data_len = data.len();
             let decompressed_sz = (((data[data_len - 1] as u32) << 24)


### PR DESCRIPTION
It seems that `zstd` has been replaced by `lz4` in 778ef82747d0284dc243a91f344e4dc281eae991.
Replace remnants accordingly.