### PR TITLE
Add --one-file-system to `bupstash put` (#90)

### DIFF
--- a/doc/man/bupstash-put.1.md
+++ b/doc/man/bupstash-put.1.md
@@ -115,6 +115,9 @@ Default tags can be overidden manually by simply specifying them.
   Suppress progress indicators (Progress indicators are also suppressed when stderr
   is not an interactive terminal).
 
+* --one-file-system:
+  Do not cross mount points in the file system.
+
 ## ENVIRONMENT
 
 * BUPSTASH_REPOSITORY:

--- a/src/client.rs
+++ b/src/client.rs
@@ -162,6 +162,7 @@ pub fn send(
     mut send_log: Option<sendlog::SendLog>,
     tags: BTreeMap<String, String>,
     data: &mut DataSource,
+    onefs: bool,
 ) -> Result<Xid, anyhow::Error> {
     let send_id = match send_log {
         Some(ref mut send_log) => send_log.last_send_id()?,
@@ -271,7 +272,7 @@ pub fn send(
                         send_log_session: &send_log_session,
                     };
 
-                    send_dir(ctx, &mut st, &base, paths, &exclusions)
+                    send_dir(ctx, &mut st, &base, paths, &exclusions, onefs)
                 };
 
                 match send_result {
@@ -636,6 +637,7 @@ fn send_dir(
     base: &std::path::PathBuf,
     paths: &[std::path::PathBuf],
     exclusions: &[glob::Pattern],
+    onefs: bool,
 ) -> Result<(), SendDirError> {
     let mut data_ectx = ctx.data_ectx.clone();
     let mut idx_ectx = ctx.idx_ectx.clone();
@@ -720,7 +722,7 @@ fn send_dir(
         // Null byte marks the end of path in the hash space.
         hash_state.update(&[0]);
 
-        let mut dir_ents = smear_try!(fsutil::read_dirents(&cur_dir));
+        let mut dir_ents = smear_try!(fsutil::read_dirents(&cur_dir, onefs));
 
         // XXX sorting by extension or reverse filename might give better compression.
         dir_ents.sort_by_key(|a| a.file_name());

--- a/src/main.rs
+++ b/src/main.rs
@@ -674,6 +674,12 @@ fn put_main(args: Vec<String>) -> Result<(), anyhow::Error> {
         "PATTERN",
     );
 
+    opts.optflag(
+        "",
+        "one-file-system",
+        "Do not cross mount points in the file system.",
+    );
+
     let matches = parse_cli_opts(opts, &args);
 
     let tag_re = regex::Regex::new(r"^([a-zA-Z0-9\\-_]+)=(.+)$").unwrap();
@@ -724,6 +730,8 @@ fn put_main(args: Vec<String>) -> Result<(), anyhow::Error> {
             Err(err) => anyhow::bail!("--exclude option {:?} is not a valid glob: {}", e, err),
         }
     }
+
+    let onefs = matches.opt_present("one-file-system");
 
     let checkpoint_bytes: u64 = match std::env::var("BUPSTASH_CHECKPOINT_BYTES") {
         Ok(v) => match v.parse() {
@@ -950,6 +958,7 @@ fn put_main(args: Vec<String>) -> Result<(), anyhow::Error> {
         send_log,
         tags,
         &mut data_source,
+        onefs,
     )?;
     client::hangup(&mut serve_in)?;
     serve_proc.wait()?;


### PR DESCRIPTION
`--one-file-system` do not cross mount points in the file system.

If `bupstash put` is told to avoid crossing a file system boundary we
need to sort out which directories to include. As such, keep track of
device inodes, and use these for comparison.