### PR TITLE
Use a bloom filter and direct mapped walk cache for gc.

### DIFF
--- a/src/abloom.rs
+++ b/src/abloom.rs
@@ -1,0 +1,183 @@
+use super::address;
+use std::convert::TryInto;
+
+// ABloom is a bloom filter specialized for addresses by taking advantage of the
+// fact that addresses are already randomly distributed.
+//
+// See https://en.wikipedia.org/wiki/Bloom_filter
+
+#[derive(Debug, PartialEq)]
+pub struct ABloom {
+    nbits: u64,
+    bytes: Vec<u8>,
+}
+
+// k is the number of hash functions in the bloom filter.
+const K: usize = 4;
+
+fn count_set_bits(bytes: &[u8]) -> u64 {
+    let mut n: u64 = 0;
+    for b in bytes.iter() {
+        n += b.count_ones() as u64;
+    }
+    n
+}
+
+pub fn approximate_mem_size_upper_bound(false_postive_rate: f64, num_addrs: u64) -> usize {
+    // see wiki: Optimal number of hash functions...
+    // > Goel and Gupta,[9] however, give a rigorous upper bound
+    // > that makes no approximations and requires no assumptions.
+    // false_positives = (1 - e ^ (-k*n/m))^k
+    // If we rearrange we get:
+    // m = -k*n/ln(1 - root(k, false_positives))
+    let k = K as f64;
+    let n = num_addrs as f64;
+    let e = false_postive_rate;
+    let m = (-k * n) / ((1.0 - e.powf(1.0 / k)).ln());
+    (m / 8.0) as usize // bits to bytes.
+}
+
+impl ABloom {
+    pub fn new(mut mem_size: usize) -> ABloom {
+        if mem_size == 0 {
+            mem_size = 1;
+        }
+
+        ABloom {
+            nbits: (mem_size as u64) * 8,
+            bytes: vec![0; mem_size],
+        }
+    }
+
+    pub fn from_bytes(bytes: Vec<u8>) -> ABloom {
+        ABloom {
+            nbits: (bytes.len() as u64) * 8,
+            bytes,
+        }
+    }
+
+    pub fn mem_size(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub fn borrow_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn num_bits(&self) -> u64 {
+        self.nbits
+    }
+
+    pub fn count_set_bits(&self) -> u64 {
+        count_set_bits(&self.bytes)
+    }
+
+    pub fn utilization(&self) -> f64 {
+        let n = count_set_bits(&self.bytes);
+        (n as f64) / (self.nbits as f64)
+    }
+
+    // Like utilization but uses a small sample
+    // to become a constant time operation.
+    pub fn estimate_utilization(&self) -> f64 {
+        const SAMPLE_ESTIMATE_BYTES: usize = 1024 * 1024;
+        let sample_size = std::cmp::min(SAMPLE_ESTIMATE_BYTES, self.bytes.len());
+        let n = count_set_bits(&self.bytes[0..sample_size]);
+        (n as f64) / ((sample_size * 8) as f64)
+    }
+
+    pub fn estimate_false_positive_rate(&self) -> f64 {
+        const N: u64 = 10000;
+        let mut false_positives = 0;
+        for _i in 0..N {
+            if self.probably_has(&address::Address::random()) {
+                false_positives += 1;
+            }
+        }
+        (false_positives as f64) / (N as f64)
+    }
+
+    pub fn estimate_add_count(&self) -> f64 {
+        let m = self.nbits as f64;
+        let x = self.count_set_bits() as f64;
+        let k = K as f64;
+        //Refer to bloom filter wiki: Approximating the number of items in a Bloom filter.
+        (-m / k) * (1.0 - (x / m)).ln()
+    }
+
+    pub fn add(&mut self, addr: &address::Address) {
+        for i in 0..K {
+            let offset_buf = addr.bytes[i * 8..(i * 8 + 8)].try_into().unwrap();
+            let bit_offset: u64 = u64::from_le_bytes(offset_buf) % self.nbits;
+            let shift = bit_offset & 7;
+            let byte_offset: usize = ((bit_offset & !7) >> 3).try_into().unwrap();
+            self.bytes[byte_offset] |= 1 << shift;
+        }
+    }
+
+    pub fn probably_has(&self, addr: &address::Address) -> bool {
+        for i in 0..K {
+            let offset_buf = addr.bytes[i * 8..(i * 8 + 8)].try_into().unwrap();
+            let bit_offset: u64 = u64::from_le_bytes(offset_buf) % self.nbits;
+            let shift = bit_offset & 7;
+            let byte_offset: usize = ((bit_offset & !7) >> 3).try_into().unwrap();
+            if (self.bytes[byte_offset] & (1 << shift)) == 0 {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::address;
+    use super::super::crypto;
+    use super::*;
+
+    #[test]
+    fn test_abloom() {
+        crypto::init();
+
+        let mut abloom = ABloom::new(8 * 1024 * 1024);
+
+        for _i in 0..10000 {
+            let addr = address::Address::random();
+            abloom.add(&addr);
+            assert!(abloom.probably_has(&addr));
+        }
+    }
+
+    #[test]
+    fn test_approximate_mem_size() {
+        crypto::init();
+        for n in [20000, 100000].iter() {
+            for p in [0.01, 0.05, 0.1, 0.5].iter() {
+                let mut abloom = ABloom::new(approximate_mem_size_upper_bound(*p, *n));
+
+                for _i in 0..*n {
+                    let addr = address::Address::random();
+                    abloom.add(&addr);
+                    assert!(abloom.probably_has(&addr));
+                }
+
+                let estimated_false_positives = abloom.estimate_false_positive_rate();
+                let prediction_delta = *p - estimated_false_positives;
+
+                eprintln!("n={}", n);
+                eprintln!("p={}", p);
+                eprintln!("mem_size={}", abloom.mem_size());
+                eprintln!(
+                    "estimated_false_positive_rate={}",
+                    estimated_false_positives,
+                );
+                eprintln!("estimated_add_count={}", abloom.estimate_add_count());
+                eprintln!("utilization={}", abloom.utilization());
+                eprintln!("estimated_utilization={}", abloom.estimate_utilization());
+                eprintln!("prediction_delta={}", prediction_delta);
+                // This test relies on probabilities to pass, if it is flaky, we can tune it.
+                assert!(prediction_delta < 0.015);
+            }
+        }
+    }
+}

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,3 +1,4 @@
+use super::crypto;
 use super::hex;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
@@ -17,6 +18,12 @@ impl fmt::Display for Address {
 }
 
 impl Address {
+    pub fn random() -> Address {
+        let mut bytes = [0; ADDRESS_SZ];
+        crypto::randombytes(&mut bytes);
+        Address { bytes }
+    }
+
     pub fn from_bytes(bytes: &[u8; 32]) -> Address {
         Address { bytes: *bytes }
     }

--- a/src/awcache.rs
+++ b/src/awcache.rs
@@ -1,0 +1,83 @@
+use super::address::*;
+use std::convert::TryInto;
+
+// AWCache is the 'address walk cache' designed to let bupstash
+// efficiently skip data during garbage collection while also
+// keeping a bound on memory use.
+//
+// The current implementation is a direct mapped cache. On hash collision
+// a value simply evicts the existing value. We could use something fancier like an lru,
+// but we need benchmarks to show it improves anything over such a simple implementaion.
+
+pub struct AWCache {
+    dm_cache_ents: Vec<Address>,
+    pub add_count: u64,
+    pub hit_count: u64,
+}
+
+impl AWCache {
+    pub fn new(cache_ents: usize) -> AWCache {
+        AWCache {
+            dm_cache_ents: vec![Address::from_bytes(&[0; ADDRESS_SZ]); cache_ents],
+            add_count: 0,
+            hit_count: 0,
+        }
+    }
+
+    pub fn add(&mut self, addr: &Address) -> bool {
+        self.add_count += 1;
+        let offset_buf = addr.bytes[0..8].try_into().unwrap();
+        let offset: u64 = u64::from_le_bytes(offset_buf) % (self.dm_cache_ents.len() as u64);
+        let mut tmp = *addr;
+        std::mem::swap(
+            &mut tmp,
+            self.dm_cache_ents.get_mut(offset as usize).unwrap(),
+        );
+        let new_val = tmp != *addr;
+        if !new_val {
+            self.hit_count += 1;
+        }
+        new_val
+    }
+
+    pub fn utilization(&self) -> f64 {
+        let mut utilized = 0;
+        for a in self.dm_cache_ents.iter() {
+            if a.bytes != [0; ADDRESS_SZ] {
+                utilized += 1
+            }
+        }
+        (utilized as f64) / (self.dm_cache_ents.len() as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::crypto;
+    use super::*;
+
+    #[test]
+    fn test_awcache() {
+        crypto::init();
+
+        let mut cache = AWCache::new(4 * 1024);
+
+        let addresses: Vec<Address> = (0..1000).map(|_| Address::random()).collect();
+
+        for a in addresses.iter() {
+            cache.add(&a);
+            assert!(!cache.add(&a));
+        }
+
+        cache.hit_count = 0;
+        cache.add_count = 0;
+
+        for a in addresses.iter() {
+            cache.add(&a);
+        }
+
+        assert!(cache.hit_count != 0);
+        eprintln!("cache hit_count: {}/{}", cache.hit_count, cache.add_count);
+        eprintln!("cache utilization: {}", cache.utilization());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
+pub mod abloom;
 pub mod address;
+pub mod awcache;
 pub mod base64;
 pub mod chunk_storage;
 pub mod chunker;


### PR DESCRIPTION
This drastically reduces memory requirements for the gc
while providing a slight increase in repository size.