### PR TITLE
No retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,9 +329,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -387,15 +387,14 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "nix"
-version = "0.17.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "void",
 ]
 
 [[package]]
@@ -750,12 +749,6 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ glob = "0.3"
 chrono = { version = "0.4", features = ["serde"]}
 cfg-if = "0.1"
 shlex = "0.1"
-nix = "0.17"
+nix = "0.20"
 indicatif = "0.15"
 rangemap = "0.1.7"
 blake3 = "0.3"

--- a/cli-tests/cli-tests.bats
+++ b/cli-tests/cli-tests.bats
@@ -441,6 +441,11 @@ _concurrent_modify_worker () {
     echo c >> $SCRATCH/t/c$2
     echo e >> $SCRATCH/t/d$2/e$2
 
+    echo "" > $SCRATCH/t/a$2
+    echo "" > $SCRATCH/t/b$2
+    echo "" > $SCRATCH/t/c$2
+    echo "" > $SCRATCH/t/d$2/e$2
+
     rm $SCRATCH/t/a$2
     rm $SCRATCH/t/b$2
     rm $SCRATCH/t/c$2

--- a/doc/cli/put.txt
+++ b/doc/cli/put.txt
@@ -1,5 +1,5 @@
-bupstash put [OPTIONS] TAGS... DIR
 bupstash put [OPTIONS] TAGS... FILE
+bupstash put [OPTIONS] TAGS... DIRS...
 bupstash put -e [OPTIONS] TAGS... CMD...
 
 `bupstash put` encrypts a file, directory, or command output and stores it

--- a/doc/man/bupstash-put.1.md
+++ b/doc/man/bupstash-put.1.md
@@ -59,6 +59,22 @@ $ bupstash put --send-log /root/bupstash-backups.sendlog /home/
 $ bupstash put --send-log /root/bupstash-backups.sendlog /home/
 ```
 
+### Concurrent filesystem modification
+
+Bupstash supports uploading a filesystem that is concurrently being modified with
+the caveat that bupstash cannot guarantee the filesystem is in a consistent state. If bupstash
+is reading a file or directory while it is concurrently being modified by an application, it may
+be the case the bupstash snapshot contains data from multiple points in time with the combination
+being invalid corrupt.
+
+The only sure way to ensure data consistency is to use in a filesystem with snapshot capabilities.
+Using filesystem snapshots you can create a consistent filesystem view and then perform a bupstash 
+backup on that snapshot. On linux some options for performing consistent
+snapshots include ZFS, BTRFS and also LVM snapshots 
+
+Another choice is to perform a put operation at a time when the files are less likely to be modified,
+this will provide backups that are good enough for many people without extra complications.
+
 ### Default tags
 
 `bupstash` automatically sets default tags.

--- a/src/client.rs
+++ b/src/client.rs
@@ -530,7 +530,7 @@ fn dir_ent_to_index_ent(
 
     let mut xattrs = None;
 
-    if want_xattrs {
+    if want_xattrs && (t.is_file() || t.is_dir()) {
         let attrs = smear_try!(xattr::list(full_path));
 
         for attr in attrs {

--- a/src/client.rs
+++ b/src/client.rs
@@ -522,7 +522,7 @@ fn dir_ent_to_index_ent(
 
     let t = metadata.file_type();
 
-    let (dev_major, dev_minor) = if t.is_block_device() || t.is_block_device() {
+    let (dev_major, dev_minor) = if t.is_block_device() || t.is_char_device() {
         (dev_major(metadata.rdev()), dev_minor(metadata.rdev()))
     } else {
         (0, 0)


### PR DESCRIPTION
Remove retry semantics from put.

Previously were aggressively retrying when an upload was interrupted by
a file system modification, but this seems futile as it will not fine
all errors and may explode bandwidth usage.

The new behavior simply skips adding missing files to the index, skips
missing extended attributes, skips missing links and takes the read file
size instead of the stat as the source of truth.
