### PR TITLE
Use an address cache for put and refactor send log.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 pub mod abloom;
-pub mod address;
 pub mod acache;
+pub mod address;
 pub mod base64;
 pub mod chunk_storage;
 pub mod chunker;

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,6 +1,6 @@
 use super::abloom;
-use super::address::*;
 use super::acache;
+use super::address::*;
 use super::chunk_storage;
 use super::compression;
 use super::dir_chunk_storage;


### PR DESCRIPTION
Use an address cache for put and refactor send log.

Use of an address cache saves lot of network io if we disable the send
log. We also refactored the send log to reduce the number of sqlite3
statements by one on each send log cache hit.

For my personal backups this address cache reduces network IO by
a quarter.
