### PR TITLE
Add server back pressure mechanism.

### DIFF
--- a/src/chunk_storage.rs
+++ b/src/chunk_storage.rs
@@ -21,7 +21,7 @@ pub trait Engine {
     fn prepare_for_gc(&mut self, gc_id: xid::Xid) -> Result<(), anyhow::Error>;
 
     // Remove all chunks not in the reachable set.
-    fn gc(&mut self, reachable: abloom::ABloom) -> Result<repository::GCStats, anyhow::Error>;
+    fn gc(&mut self, reachable: abloom::ABloom) -> Result<repository::GcStats, anyhow::Error>;
 
     // Check that a previous invocation of gc has finished.
     fn gc_completed(&mut self, gc_id: xid::Xid) -> Result<bool, anyhow::Error>;

--- a/src/client.rs
+++ b/src/client.rs
@@ -37,9 +37,7 @@ pub enum ClientError {
     #[error("corrupt or tampered data")]
     CorruptOrTamperedData,
     #[error("server overloaded")]
-    ServerOverloaded,
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
+    ServerUnavailable,
 }
 
 pub fn open_repository(
@@ -56,8 +54,8 @@ pub fn open_repository(
     )?;
 
     match read_packet_raw(r, DEFAULT_MAX_PACKET_SIZE)? {
-        Packet::Abort(Abort { code, .. }) if code == Some(ABORT_CODE_SERVER_OVERLOADED) => {
-            return Err(ClientError::ServerOverloaded.into())
+        Packet::Abort(Abort { code, .. }) if code == Some(ABORT_CODE_SERVER_UNAVAILABLE) => {
+            return Err(ClientError::ServerUnavailable.into())
         }
         Packet::Abort(Abort { message, .. }) => anyhow::bail!("remote error: {}", message),
         Packet::ROpenRepository(resp) => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -454,8 +454,8 @@ cfg_if::cfg_if! {
 }
 
 fn dir_ent_to_index_ent(
-    full_path: &std::path::PathBuf,
-    short_path: &std::path::PathBuf,
+    full_path: &std::path::Path,
+    short_path: &std::path::Path,
     metadata: &std::fs::Metadata,
     want_xattrs: bool,
 ) -> Result<index::IndexEntry, std::io::Error> {
@@ -631,7 +631,7 @@ cfg_if::cfg_if! {
 fn send_dir(
     ctx: &SendContext,
     st: &mut SendDirState,
-    base: &std::path::PathBuf,
+    base: &std::path::Path,
     paths: &[std::path::PathBuf],
     exclusions: &[glob::Pattern],
 ) -> Result<(), anyhow::Error> {
@@ -647,7 +647,13 @@ fn send_dir(
     }
 
     let ent = index::VersionedIndexEntry::V2(
-        dir_ent_to_index_ent(&base, &".".into(), &metadata, ctx.want_xattrs).map_err(|err| {
+        dir_ent_to_index_ent(
+            &base,
+            &std::path::PathBuf::from("."),
+            &metadata,
+            ctx.want_xattrs,
+        )
+        .map_err(|err| {
             anyhow::format_err!("unable build index entry for {}: {}", base.display(), err)
         })?,
     );
@@ -1459,7 +1465,7 @@ pub fn gc(
     progress: indicatif::ProgressBar,
     r: &mut dyn std::io::Read,
     w: &mut dyn std::io::Write,
-) -> Result<repository::GCStats, anyhow::Error> {
+) -> Result<repository::GcStats, anyhow::Error> {
     progress.set_message("collecting garbage...");
 
     write_packet(w, &Packet::TGc(TGc {}))?;

--- a/src/dir_chunk_storage.rs
+++ b/src/dir_chunk_storage.rs
@@ -364,7 +364,7 @@ impl Engine for DirStorage {
         Ok(std::fs::read_dir(&self.dir_path)?.count().try_into()?)
     }
 
-    fn gc(&mut self, reachable: abloom::ABloom) -> Result<repository::GCStats, anyhow::Error> {
+    fn gc(&mut self, reachable: abloom::ABloom) -> Result<repository::GcStats, anyhow::Error> {
         self.stop_workers();
 
         assert!(self.gc_exclusive_lock.is_some());
@@ -408,7 +408,7 @@ impl Engine for DirStorage {
 
         self.gc_exclusive_lock = None;
 
-        Ok(repository::GCStats {
+        Ok(repository::GcStats {
             chunks_remaining: Some(chunks_remaining),
             chunks_deleted: Some(chunks_deleted),
             bytes_deleted: Some(bytes_deleted),

--- a/src/external_chunk_storage.rs
+++ b/src/external_chunk_storage.rs
@@ -72,11 +72,11 @@ impl Engine for ExternalStorage {
     fn prepare_for_gc(&mut self, gc_id: xid::Xid) -> Result<(), anyhow::Error> {
         protocol::write_packet(
             &mut self.sock,
-            &protocol::Packet::TStoragePrepareForGC(gc_id),
+            &protocol::Packet::TStoragePrepareForGc(gc_id),
         )?;
         match protocol::read_packet(&mut self.sock, protocol::DEFAULT_MAX_PACKET_SIZE) {
-            Ok(protocol::Packet::RStoragePrepareForGC) => (),
-            Ok(_) => anyhow::bail!("unexpected packet response, expected RStoragePrepareForGC"),
+            Ok(protocol::Packet::RStoragePrepareForGc) => (),
+            Ok(_) => anyhow::bail!("unexpected packet response, expected RStoragePrepareForGc"),
             Err(err) => return Err(err),
         }
         Ok(())
@@ -86,21 +86,21 @@ impl Engine for ExternalStorage {
         protocol::write_packet(&mut self.sock, &protocol::Packet::TStorageEstimateCount)?;
         match protocol::read_packet(&mut self.sock, protocol::DEFAULT_MAX_PACKET_SIZE) {
             Ok(protocol::Packet::RStorageEstimateCount(v)) => Ok(v.count.0),
-            Ok(_) => anyhow::bail!("unexpected packet response, expected RStoragePrepareForGC"),
+            Ok(_) => anyhow::bail!("unexpected packet response, expected RStorageEstimateCount"),
             Err(err) => Err(err),
         }
     }
 
-    fn gc(&mut self, reachable: abloom::ABloom) -> Result<repository::GCStats, anyhow::Error> {
+    fn gc(&mut self, reachable: abloom::ABloom) -> Result<repository::GcStats, anyhow::Error> {
         protocol::write_begin_gc(&mut self.sock, &reachable)?;
         std::mem::drop(reachable);
         match protocol::read_packet(&mut self.sock, protocol::DEFAULT_MAX_PACKET_SIZE) {
-            Ok(protocol::Packet::StorageGCComplete(stats)) => {
+            Ok(protocol::Packet::StorageGcComplete(stats)) => {
                 let _ =
                     protocol::write_packet(&mut self.sock, &protocol::Packet::EndOfTransmission);
                 Ok(stats)
             }
-            Ok(_) => anyhow::bail!("unexpected packet response, expected StorageGCComplete"),
+            Ok(_) => anyhow::bail!("unexpected packet response, expected StorageGcComplete"),
             Err(err) => Err(err),
         }
     }
@@ -108,11 +108,11 @@ impl Engine for ExternalStorage {
     fn gc_completed(&mut self, gc_id: xid::Xid) -> Result<bool, anyhow::Error> {
         protocol::write_packet(
             &mut self.sock,
-            &protocol::Packet::TStorageGCCompleted(gc_id),
+            &protocol::Packet::TStorageGcCompleted(gc_id),
         )?;
         match protocol::read_packet(&mut self.sock, protocol::DEFAULT_MAX_PACKET_SIZE)? {
-            protocol::Packet::RStorageGCCompleted(completed) => Ok(completed),
-            _ => anyhow::bail!("unexpected packet response, expected RStorageAwaitGCCompletion"),
+            protocol::Packet::RStorageGcCompleted(completed) => Ok(completed),
+            _ => anyhow::bail!("unexpected packet response, expected RStorageGcCompleted"),
         }
     }
 }

--- a/src/htree.rs
+++ b/src/htree.rs
@@ -164,7 +164,7 @@ impl TreeWriter {
         // The tree blocks must contain whole addresses.
         assert!((self.tree_blocks[level].len() % (8 + ADDRESS_SZ)) == 0);
         self.clear_level(sink, level)?;
-        Ok(self.finish_level(sink, level + 1)?)
+        self.finish_level(sink, level + 1)
     }
 
     pub fn finish(

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,13 +430,16 @@ fn cli_to_opened_serve_process(
                 return Ok(remote);
             }
             Err(err) => {
-                if let Some(client::ClientError::ServerUnavailable) =
+                if let Some(protocol::AbortError::ServerUnavailable { message, .. }) =
                     err.root_cause().downcast_ref()
                 {
                     if retry_count == 1 {
                         // Print after the second retry so that DNS load balancing can resolve
                         // the problem if the server supports this.
-                        progress.println("server is overloaded, retrying after delay.");
+                        progress.println(format!(
+                            "server is unavailable ({}), retrying after delay.",
+                            message
+                        ));
                     }
                     std::thread::sleep(std::time::Duration::from_secs(retry_duration));
                     retry_duration = (retry_duration * 2).min(180);

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,7 +430,8 @@ fn cli_to_opened_serve_process(
                 return Ok(remote);
             }
             Err(err) => {
-                if let Some(client::ClientError::ServerOverloaded) = err.root_cause().downcast_ref()
+                if let Some(client::ClientError::ServerUnavailable) =
+                    err.root_cause().downcast_ref()
                 {
                     if retry_count == 1 {
                         // Print after the second retry so that DNS load balancing can resolve

--- a/src/pem.rs
+++ b/src/pem.rs
@@ -66,9 +66,9 @@ static ASCII_ARMOR: Lazy<Regex> = Lazy::new(|| Regex::new(REGEX_STR).unwrap());
 #[derive(Debug, Clone, Copy)]
 pub enum LineEnding {
     /// Windows-like (`\r\n`)
-    CRLF,
+    Crlf,
     /// Unix-like (`\n`)
-    LF,
+    Lf,
 }
 
 /// Configuration for Pem encoding
@@ -90,7 +90,7 @@ pub struct Pem {
 impl Pem {
     fn new_from_captures(caps: Captures) -> Result<Pem> {
         fn as_utf8(bytes: &[u8]) -> Result<&str> {
-            Ok(str::from_utf8(bytes).map_err(PemError::NotUtf8)?)
+            str::from_utf8(bytes).map_err(PemError::NotUtf8)
         }
 
         // Verify that the begin section exists
@@ -277,7 +277,7 @@ pub fn encode(pem: &Pem) -> String {
     encode_config(
         pem,
         EncodeConfig {
-            line_ending: LineEnding::CRLF,
+            line_ending: LineEnding::Crlf,
         },
     )
 }
@@ -293,12 +293,12 @@ pub fn encode(pem: &Pem) -> String {
 ///     tag: String::from("FOO"),
 ///     contents: vec![1, 2, 3, 4],
 ///   };
-///   encode_config(&pem, EncodeConfig { line_ending: LineEnding::LF });
+///   encode_config(&pem, EncodeConfig { line_ending: LineEnding::Lf });
 /// ```
 pub fn encode_config(pem: &Pem, config: EncodeConfig) -> String {
     let line_ending = match config.line_ending {
-        LineEnding::CRLF => "\r\n",
-        LineEnding::LF => "\n",
+        LineEnding::Crlf => "\r\n",
+        LineEnding::Lf => "\n",
     };
 
     let mut output = String::new();
@@ -362,12 +362,12 @@ pub fn encode_many(pems: &[Pem]) -> String {
 ///         contents: vec![5, 6, 7, 8],
 ///     },
 ///   ];
-///   encode_many_config(&data, EncodeConfig { line_ending: LineEnding::LF });
+///   encode_many_config(&data, EncodeConfig { line_ending: LineEnding::Lf });
 /// ```
 pub fn encode_many_config(pems: &[Pem], config: EncodeConfig) -> String {
     let line_ending = match config.line_ending {
-        LineEnding::CRLF => "\r\n",
-        LineEnding::LF => "\n",
+        LineEnding::Crlf => "\r\n",
+        LineEnding::Lf => "\n",
     };
     pems.iter()
         .map(|value| encode_config(value, config))
@@ -536,7 +536,7 @@ RzHX0lkJl9Stshd/7Gbt65/QYq+v+xvAeT0CoyIg
             contents: vec![1, 2, 3, 4],
         };
         let config = EncodeConfig {
-            line_ending: LineEnding::LF,
+            line_ending: LineEnding::Lf,
         };
         let encoded = encode_config(&pem, config);
         assert!(encoded != "");
@@ -549,7 +549,7 @@ RzHX0lkJl9Stshd/7Gbt65/QYq+v+xvAeT0CoyIg
     fn test_encode_many_config() {
         let pems = parse_many(SAMPLE_LF);
         let config = EncodeConfig {
-            line_ending: LineEnding::LF,
+            line_ending: LineEnding::Lf,
         };
         let encoded = encode_many_config(&pems, config);
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -9,7 +9,7 @@ use std::convert::TryInto;
 
 pub const DEFAULT_MAX_PACKET_SIZE: usize = 1024 * 1024 * 16;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 pub enum OpenMode {
     Read,
     ReadWrite,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -106,7 +106,7 @@ pub enum Progress {
     SetMessage(String),
 }
 
-pub const ABORT_CODE_SERVER_OVERLOADED: u64 = 0x9cf5c3ce325d27a6;
+pub const ABORT_CODE_SERVER_UNAVAILABLE: u64 = 0x9cf5c3ce325d27a6;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Abort {

--- a/src/querycache.rs
+++ b/src/querycache.rs
@@ -2,7 +2,7 @@ use super::crypto;
 use super::itemset;
 use super::query;
 use super::xid::*;
-use std::path::PathBuf;
+use std::path::Path;
 
 pub struct QueryCache {
     conn: rusqlite::Connection,
@@ -22,7 +22,7 @@ pub struct ListOptions {
 }
 
 impl QueryCache {
-    pub fn open(p: &PathBuf) -> Result<QueryCache, anyhow::Error> {
+    pub fn open(p: &Path) -> Result<QueryCache, anyhow::Error> {
         let mut conn = rusqlite::Connection::open(p)?;
         conn.query_row("pragma journal_mode=WAL;", rusqlite::NO_PARAMS, |_r| Ok(()))?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -171,8 +171,8 @@ fn recv(
     w: &mut dyn std::io::Write,
 ) -> Result<(), anyhow::Error> {
     let gc_generation = match repo.gc_status()? {
-        repository::GCStatus::Complete(gc_generation) => gc_generation,
-        repository::GCStatus::Running(_) => {
+        repository::GcStatus::Complete(gc_generation) => gc_generation,
+        repository::GcStatus::Running(_) => {
             // We can only start a recv if we aren't currently
             // performing a garbage collection, otherwise we might
             // accept an upload that occured during the sweep

--- a/src/xid.rs
+++ b/src/xid.rs
@@ -21,7 +21,7 @@ impl Xid {
         if s.len() != 32 {
             anyhow::bail!("invalid id, should be 32 characters long");
         }
-        if hex::decode(&s[..], &mut bytes[..]).is_err() {
+        if hex::decode(s, &mut bytes[..]).is_err() {
             anyhow::bail!("invalid id, should be a hex value");
         }
         Ok(Xid { bytes })


### PR DESCRIPTION
A server can now signal to clients it is overloaded,
New clients respect this with exponential backoff. Old clients will simply
return an error when seeing this message.

This reconnect is very useful for larger servers that do round robin load balancing.