### PR TITLE
Mitigate timestamp spoofing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "bupstash"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bupstash"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Andrew Chambers <ac@acha.ninja>"]
 edition = "2018"
 license = "MIT"

--- a/doc/man/bupstash-repository.7.md
+++ b/doc/man/bupstash-repository.7.md
@@ -71,20 +71,24 @@ type RemoveItems {
   items: []Xid
 }
 
-type VersionedItemMetadata = (V1VersionedItemMetadata | ...)
+type VersionedItemMetadata = (V1VersionedItemMetadata | V2VersionedItemMetadata)
 
 type V1VersionedItemMetadata {
+  // deprecated in bupstash version 0.9
+}
+
+type V2VersionedItemMetadata {
   primary_key_id: Xid,
+  unix_timestamp_millis: u64,
   tree_height: usize,
   address: Address,
   encryped_metadata: data
 }
 
-struct V1EncryptedItemMetadata {
+struct V2SecretItemMetadata {
   plain_text_hash: data<32>
   send_key_id: Xid,
   hash_key_part_2: data<32>,
-  timestamp: String,
   tags: Map[String]String,
 }
 

--- a/src/itemset.rs
+++ b/src/itemset.rs
@@ -7,7 +7,7 @@ pub const MAX_TAG_SET_SIZE: usize = 32 * 1024;
 // Tags plus some leeway, we can adjust this if we need to.
 pub const MAX_METADATA_SIZE: usize = MAX_TAG_SET_SIZE + 2048;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 pub struct HTreeMetadata {
     pub height: serde_bare::Uint,
     pub data_chunk_count: serde_bare::Uint,
@@ -15,13 +15,13 @@ pub struct HTreeMetadata {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct PlainTextItemMetadata {
+pub struct V1PlainTextItemMetadata {
     pub primary_key_id: Xid,
     pub data_tree: HTreeMetadata,
     pub index_tree: Option<HTreeMetadata>,
 }
 
-impl PlainTextItemMetadata {
+impl V1PlainTextItemMetadata {
     pub fn hash(&self) -> [u8; crypto::HASH_BYTES] {
         let mut hst = crypto::HashState::new(None);
         hst.update(&serde_bare::to_vec(&self).unwrap());
@@ -30,44 +30,156 @@ impl PlainTextItemMetadata {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct EncryptedItemMetadata {
+pub struct V2PlainTextItemMetadata {
+    pub primary_key_id: Xid,
+    pub unix_timestamp_millis: u64,
+    pub data_tree: HTreeMetadata,
+    pub index_tree: Option<HTreeMetadata>,
+}
+
+impl V2PlainTextItemMetadata {
+    pub fn hash(&self) -> [u8; crypto::HASH_BYTES] {
+        let mut hst = crypto::HashState::new(None);
+        hst.update(&serde_bare::to_vec(&self).unwrap());
+        hst.finish()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct V1SecretItemMetadata {
     pub plain_text_hash: [u8; crypto::HASH_BYTES],
     pub send_key_id: Xid,
     pub idx_hash_key_part_2: crypto::PartialHashKey,
     pub data_hash_key_part_2: crypto::PartialHashKey,
     pub timestamp: chrono::DateTime<chrono::Utc>,
-    // We want ordered serialization.
     pub tags: std::collections::BTreeMap<String, String>,
     pub data_size: serde_bare::Uint,
-    // 0 if we have no index.
     pub index_size: serde_bare::Uint,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct ItemMetadata {
-    pub plain_text_metadata: PlainTextItemMetadata,
-    // An encrypted instance of EncryptedItemMetadata
+pub struct V2SecretItemMetadata {
+    pub plain_text_hash: [u8; crypto::HASH_BYTES],
+    pub send_key_id: Xid,
+    pub idx_hash_key_part_2: crypto::PartialHashKey,
+    pub data_hash_key_part_2: crypto::PartialHashKey,
+    pub tags: std::collections::BTreeMap<String, String>,
+    pub data_size: serde_bare::Uint,
+    pub index_size: serde_bare::Uint,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct V1ItemMetadata {
+    pub plain_text_metadata: V1PlainTextItemMetadata,
     pub encrypted_metadata: Vec<u8>,
 }
 
-impl ItemMetadata {
-    pub fn decrypt_metadata(
-        &self,
-        dctx: &mut crypto::DecryptionContext,
-    ) -> Result<EncryptedItemMetadata, anyhow::Error> {
-        let data = dctx.decrypt_data(self.encrypted_metadata.clone())?;
-        let emd: EncryptedItemMetadata = serde_bare::from_slice(&data)?;
-        if self.plain_text_metadata.hash() != emd.plain_text_hash {
-            anyhow::bail!("item metadata is corrupt or tampered with");
-        }
-        Ok(emd)
-    }
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct V2ItemMetadata {
+    pub plain_text_metadata: V2PlainTextItemMetadata,
+    pub encrypted_metadata: Vec<u8>,
 }
 
 #[non_exhaustive]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum VersionedItemMetadata {
-    V1(ItemMetadata),
+    V1(V1ItemMetadata), // Note, we are considering removing this version in the future and removing support.
+    V2(V2ItemMetadata),
+}
+
+// This type is the result of decrypting and validating either V1 metadata or V2 metadata
+// It is the lowest common denominator of all metadata.
+#[derive(Debug, PartialEq, Clone)]
+pub struct DecryptedItemMetadata {
+    pub primary_key_id: Xid,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub data_tree: HTreeMetadata,
+    pub index_tree: Option<HTreeMetadata>,
+    pub plain_text_hash: [u8; crypto::HASH_BYTES],
+    pub send_key_id: Xid,
+    pub idx_hash_key_part_2: crypto::PartialHashKey,
+    pub data_hash_key_part_2: crypto::PartialHashKey,
+    pub tags: std::collections::BTreeMap<String, String>,
+    pub data_size: serde_bare::Uint,
+    pub index_size: serde_bare::Uint,
+}
+
+impl VersionedItemMetadata {
+    pub fn primary_key_id(&self) -> &Xid {
+        match self {
+            VersionedItemMetadata::V1(ref md) => &md.plain_text_metadata.primary_key_id,
+            VersionedItemMetadata::V2(ref md) => &md.plain_text_metadata.primary_key_id,
+        }
+    }
+
+    pub fn index_tree(&self) -> Option<&HTreeMetadata> {
+        match self {
+            VersionedItemMetadata::V1(ref md) => md.plain_text_metadata.index_tree.as_ref(),
+            VersionedItemMetadata::V2(ref md) => md.plain_text_metadata.index_tree.as_ref(),
+        }
+    }
+
+    pub fn data_tree(&self) -> &HTreeMetadata {
+        match self {
+            VersionedItemMetadata::V1(ref md) => &md.plain_text_metadata.data_tree,
+            VersionedItemMetadata::V2(ref md) => &md.plain_text_metadata.data_tree,
+        }
+    }
+
+    pub fn decrypt_metadata(
+        &self,
+        dctx: &mut crypto::DecryptionContext,
+    ) -> Result<DecryptedItemMetadata, anyhow::Error> {
+        match self {
+            VersionedItemMetadata::V1(ref md) => {
+                let data = dctx.decrypt_data(md.encrypted_metadata.clone())?;
+                let emd: V1SecretItemMetadata = serde_bare::from_slice(&data)?;
+                if md.plain_text_metadata.hash() != emd.plain_text_hash {
+                    anyhow::bail!("item metadata is corrupt or tampered with");
+                }
+                Ok(DecryptedItemMetadata {
+                    primary_key_id: md.plain_text_metadata.primary_key_id,
+                    data_tree: md.plain_text_metadata.data_tree,
+                    index_tree: md.plain_text_metadata.index_tree,
+                    plain_text_hash: emd.plain_text_hash,
+                    send_key_id: emd.send_key_id,
+                    idx_hash_key_part_2: emd.idx_hash_key_part_2,
+                    data_hash_key_part_2: emd.data_hash_key_part_2,
+                    timestamp: emd.timestamp,
+                    tags: emd.tags,
+                    data_size: emd.data_size,
+                    index_size: emd.index_size,
+                })
+            }
+            VersionedItemMetadata::V2(ref md) => {
+                let data = dctx.decrypt_data(md.encrypted_metadata.clone())?;
+                let emd: V2SecretItemMetadata = serde_bare::from_slice(&data)?;
+                if md.plain_text_metadata.hash() != emd.plain_text_hash {
+                    anyhow::bail!("item metadata is corrupt or tampered with");
+                }
+                let ts_millis = md.plain_text_metadata.unix_timestamp_millis as i64;
+                let ts_secs = ts_millis / 1000;
+                let ts_nsecs = ((ts_millis % 1000) * 1000000) as u32;
+                let ts = chrono::DateTime::<chrono::Utc>::from_utc(
+                    chrono::NaiveDateTime::from_timestamp(ts_secs, ts_nsecs),
+                    chrono::Utc,
+                );
+                Ok(DecryptedItemMetadata {
+                    primary_key_id: md.plain_text_metadata.primary_key_id,
+                    plain_text_hash: emd.plain_text_hash,
+                    data_tree: md.plain_text_metadata.data_tree,
+                    index_tree: md.plain_text_metadata.index_tree,
+                    send_key_id: emd.send_key_id,
+                    idx_hash_key_part_2: emd.idx_hash_key_part_2,
+                    data_hash_key_part_2: emd.data_hash_key_part_2,
+                    timestamp: ts,
+                    tags: emd.tags,
+                    data_size: emd.data_size,
+                    index_size: emd.index_size,
+                })
+            }
+        }
+    }
 }
 
 #[non_exhaustive]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1164,10 +1164,9 @@ fn get_main(args: Vec<String>) -> Result<(), anyhow::Error> {
     };
 
     progress.set_message("fetching item metadata...");
-    let itemset::VersionedItemMetadata::V1(metadata) =
-        client::request_metadata(id, &mut serve_out, &mut serve_in)?;
+    let metadata = client::request_metadata(id, &mut serve_out, &mut serve_in)?;
 
-    let mut content_index = if metadata.plain_text_metadata.index_tree.is_some() {
+    let mut content_index = if metadata.index_tree().is_some() {
         Some(client::request_index(
             client::IndexRequestContext {
                 primary_key_id,
@@ -1408,10 +1407,9 @@ fn list_contents_main(args: Vec<String>) -> Result<(), anyhow::Error> {
     };
 
     progress.set_message("fetching item metadata...");
-    let itemset::VersionedItemMetadata::V1(metadata) =
-        client::request_metadata(id, &mut serve_out, &mut serve_in)?;
+    let metadata = client::request_metadata(id, &mut serve_out, &mut serve_in)?;
 
-    if metadata.plain_text_metadata.index_tree.is_none() {
+    if metadata.index_tree().is_none() {
         anyhow::bail!(
             "list-contents is only supported for directory snapshots created by bupstash"
         );
@@ -1627,10 +1625,9 @@ fn diff_main(args: Vec<String>) -> Result<(), anyhow::Error> {
         };
 
         progress.set_message("fetching item metadata...");
-        let itemset::VersionedItemMetadata::V1(metadata) =
-            client::request_metadata(id, &mut serve_out, &mut serve_in)?;
+        let metadata = client::request_metadata(id, &mut serve_out, &mut serve_in)?;
 
-        if metadata.plain_text_metadata.index_tree.is_none() {
+        if metadata.index_tree().is_none() {
             anyhow::bail!("diff is only supported for directory snapshots created by bupstash");
         }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -29,7 +29,7 @@ pub struct TOpenRepository {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct ROpenRepository {
-    pub now: chrono::DateTime<chrono::Utc>,
+    pub unix_now_millis: u64,
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
Previously timestamps were encrypted by the client, but this meant the
server had no way to verify them. Now both the server and client must
independently verify a metadata timestamp is valid before accepting.

This change warrants a new metadata version as it could be used during
an attack to spoof timestamps in a way that could confuse someone trying
to recover a system, even if they knew the date of the breach.

We also took this opportunity to change complex string timestamps to a
simpler unix millisecond timestamp.