### PR TITLE
Refactor send log to skip more work.

### DIFF
--- a/src/chunk_storage.rs
+++ b/src/chunk_storage.rs
@@ -1,6 +1,5 @@
 use super::abloom;
 use super::address::*;
-use super::htree;
 use super::protocol;
 use super::repository;
 use super::xid;
@@ -42,16 +41,4 @@ pub trait Engine {
     // make a rough guess to increase performance. One trick is sampling
     // a single address prefix.
     fn estimate_chunk_count(&mut self) -> Result<u64, anyhow::Error>;
-}
-
-impl htree::Sink for Box<dyn Engine> {
-    fn add_chunk(&mut self, addr: &Address, buf: Vec<u8>) -> Result<(), anyhow::Error> {
-        self.as_mut().add_chunk(addr, buf)
-    }
-}
-
-impl htree::Source for Box<dyn Engine> {
-    fn get_chunk(&mut self, addr: &Address) -> Result<Vec<u8>, anyhow::Error> {
-        self.as_mut().get_chunk(addr)
-    }
 }

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -103,6 +103,12 @@ impl RollsumChunker {
         }
     }
 
+    pub fn take_buffered(&mut self) -> Vec<u8> {
+        let mut v = Vec::new();
+        std::mem::swap(&mut self.cur_vec, &mut v);
+        v
+    }
+
     pub fn finish(self) -> Vec<u8> {
         self.cur_vec
     }


### PR DESCRIPTION
Previously we encrypted and compressed data before
checking the send log, now we skip that work.