### PR TITLE
Make the op log format a true log.

### DIFF
--- a/doc/man/bupstash-repository.7.md
+++ b/doc/man/bupstash-repository.7.md
@@ -64,6 +64,7 @@ type Address data<32>;
 type LogOp  (AddItem | RemoveItems);
   
 type AddItem {
+  id: Xid
   metadata: VersionedItemMetadata 
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -48,7 +48,7 @@ pub fn open_repository(
         w,
         &Packet::TOpenRepository(TOpenRepository {
             open_mode,
-            protocol_version: "7".to_string(),
+            protocol_version: "8".to_string(),
         }),
     )?;
 
@@ -1615,8 +1615,8 @@ pub fn sync(
                 if ops.is_empty() {
                     break;
                 }
-                for (opid, item_id, op) in ops {
-                    tx.sync_op(opid, item_id, op)?;
+                for (opid, op) in ops {
+                    tx.sync_op(opid.0, op)?;
                 }
             }
             _ => anyhow::bail!("protocol error, expected items packet"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -742,9 +742,7 @@ fn list_main(args: Vec<String>) -> Result<(), anyhow::Error> {
                     writeln!(out, "}}")?;
                     writeln!(out, "}}")?;
                 }
-                ListFormat::Bare => {
-                    anyhow::bail!("unsupported list format")
-                }
+                ListFormat::Bare => anyhow::bail!("unsupported list format"),
             }
 
             Ok(())

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -154,7 +154,7 @@ pub enum Packet {
     RGc(RGc),
     TRequestItemSync(TRequestItemSync),
     RRequestItemSync(RRequestItemSync),
-    SyncLogOps(Vec<(i64, Option<Xid>, itemset::LogOp)>),
+    SyncLogOps(Vec<(serde_bare::Uint, itemset::LogOp)>),
     TRequestChunkData(Address),
     RRequestChunkData(Vec<u8>),
     Progress(Progress),

--- a/src/querycache.rs
+++ b/src/querycache.rs
@@ -53,13 +53,13 @@ impl QueryCache {
             },
         ) {
             Ok(v) => {
-                if v != 1 {
-                    anyhow::bail!("query cache at {:?} is from a different version of the software and must be removed manually", &p);
+                if v != 2 {
+                    anyhow::bail!("query cache at {:?} is from an incompatible version of the software and must be removed manually", &p);
                 }
             }
             Err(rusqlite::Error::QueryReturnedNoRows) => {
                 tx.execute(
-                    "insert into QueryCacheMeta(Key, Value) values('schema-version', 1);",
+                    "insert into QueryCacheMeta(Key, Value) values('schema-version', 2);",
                     rusqlite::NO_PARAMS,
                 )?;
 
@@ -180,13 +180,8 @@ impl<'a> QueryCacheTx<'a> {
         Ok(())
     }
 
-    pub fn sync_op(
-        &mut self,
-        op_id: i64,
-        item_id: Option<Xid>,
-        op: itemset::LogOp,
-    ) -> Result<(), anyhow::Error> {
-        itemset::sync_ops(&self.tx, op_id, item_id, &op)
+    pub fn sync_op(&mut self, op_id: u64, op: itemset::LogOp) -> Result<(), anyhow::Error> {
+        itemset::sync_op(&self.tx, op_id, &op)
     }
 
     pub fn commit(self) -> Result<(), anyhow::Error> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -26,7 +26,7 @@ pub fn serve(
     loop {
         match read_packet(r, DEFAULT_MAX_PACKET_SIZE)? {
             Packet::TOpenRepository(req) => {
-                if req.protocol_version != "7" {
+                if req.protocol_version != "8" {
                     anyhow::bail!(
                         "server does not support bupstash protocol version {}",
                         req.protocol_version


### PR DESCRIPTION
The item id should be part of the log so we can
recreate the repository state by replaying all ops.