### PR TITLE
Convert index format to use relative chunk offsets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ in a backwards incompatible way unless there is *very* strong justification. Fut
 Initialize a new Bupstash repository via ssh.
 ```
 $ export BUPSTASH_REPOSITORY=ssh://$SERVER/home/me/backups
+$ # Ensure bupstash is on the $PATH of both machines.
 $ bupstash init
 ```
 

--- a/cli-tests/mk-random-dir.py
+++ b/cli-tests/mk-random-dir.py
@@ -1,0 +1,49 @@
+#! /usr/bin/env python3
+
+import string
+import random
+import os
+import os.path as path
+import sys
+
+MIN_NAME_LEN = 1
+MAX_NAME_LEN = 8
+MIN_CHILD_DIRS = 0
+MAX_CHILD_DIRS = 3
+MIN_CHILD_FILES = 0
+MAX_CHILD_FILES = 5
+MIN_DEPTH = 0
+MAX_DEPTH = 3
+FILE_SIZES = [0, 1, 2, 3, 1024, 512*1024, 2*1024*1024, 8*1024*1024]
+
+def random_file_name():
+  name_len = random.randint(MIN_NAME_LEN, MAX_NAME_LEN)
+  return ''.join(random.choices(string.ascii_lowercase, k=name_len))
+
+def fresh_dir_ent(dir_path):
+  while True:
+    p = path.join(dir_path, random_file_name())
+    if not path.exists(p):
+      return p
+  
+def random_dir(dir_path="./random_dir", depth=None):
+
+  if depth is None:
+    depth = random.randint(MIN_DEPTH, MAX_DEPTH)
+
+  os.mkdir(dir_path)
+
+  num_files = random.randint(MIN_CHILD_FILES, MAX_CHILD_FILES)
+  num_dirs = random.randint(MIN_CHILD_DIRS, MAX_CHILD_DIRS)
+
+  if depth != 0:
+    for i in range(num_dirs):
+      random_dir(dir_path=fresh_dir_ent(dir_path), depth=depth-1)
+
+  for i in range(num_files):
+    with open(fresh_dir_ent(dir_path), "wb") as f:
+      fsize = random.choice(FILE_SIZES)
+      f.write(os.urandom(fsize))
+
+if __name__ == '__main__':
+  random_dir(sys.argv[1])

--- a/cli-tests/parallel-thrash.sh
+++ b/cli-tests/parallel-thrash.sh
@@ -23,7 +23,7 @@ inc_result () {
 }
 
 thrash_worker () {
-  for i in $(seq 50)
+  for i in $(seq 30)
   do
     expected=$(uuidgen)
     
@@ -85,7 +85,7 @@ bupstash_serve_chaos_worker () {
 }
 
 # Outer loop is to control the size of the gc set.
-for i in $(seq 50)
+for i in $(seq 30)
 do
 
   bupstash rm --allow-many thrash_test=yes >&2

--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 // N.B.
-// fsutil file locks uses fcntl style locks, which have error prone semantics,
+// fsutil file locks use fcntl style locks. These have error prone semantics,
 // but are widely supported. The semantics mean a lock is process global and
 // you can't open a file with lock multiple times from the same process and expect
 // them to block eachother. To mitigate this problem, bupstash creates a global

--- a/src/main.rs
+++ b/src/main.rs
@@ -1648,7 +1648,7 @@ fn diff_main(args: Vec<String>) -> Result<(), anyhow::Error> {
         },
         None => ListFormat::Human,
     };
-    let mut diff_mask = index::INDEX_COMPARE_MASK_OFFSETS;
+    let mut diff_mask = index::INDEX_COMPARE_MASK_DATA_CURSORS;
 
     if let Some(ignore) = matches.opt_str("ignore") {
         for ignore in ignore.split(',') {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use thiserror::Error;
 
+pub const CURRENT_REPOSITORY_PROTOCOL_VERSION: &str = "9";
 pub const DEFAULT_MAX_PACKET_SIZE: usize = 1024 * 1024 * 16;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]

--- a/src/sendlog.rs
+++ b/src/sendlog.rs
@@ -19,7 +19,7 @@ pub struct SendLogSession<'a> {
 pub struct StatCacheEntry {
     pub total_size: u64,
     pub addresses: Vec<Address>,
-    pub base_offsets: Vec<index::IndexEntryOffsets>,
+    pub data_cursors: Vec<index::RelativeDataCursor>,
     pub hashes: Vec<index::ContentCryptoHash>,
 }
 
@@ -386,7 +386,7 @@ mod tests {
                     &StatCacheEntry {
                         total_size: 123,
                         addresses: vec![],
-                        base_offsets: vec![],
+                        data_cursors: vec![],
                         hashes: vec![],
                     },
                 )
@@ -454,7 +454,7 @@ mod tests {
                     &StatCacheEntry {
                         total_size: 123,
                         addresses: vec![],
-                        base_offsets: vec![],
+                        data_cursors: vec![],
                         hashes: vec![],
                     },
                 )
@@ -519,7 +519,7 @@ mod tests {
                     &StatCacheEntry {
                         total_size: 123,
                         addresses: vec![],
-                        base_offsets: vec![],
+                        data_cursors: vec![],
                         hashes: vec![],
                     },
                 )
@@ -539,7 +539,7 @@ mod tests {
                     &StatCacheEntry {
                         total_size: 123,
                         addresses: vec![],
-                        base_offsets: vec![],
+                        data_cursors: vec![],
                         hashes: vec![],
                     },
                 )

--- a/src/server.rs
+++ b/src/server.rs
@@ -26,10 +26,11 @@ pub fn serve(
     loop {
         match read_packet(r, DEFAULT_MAX_PACKET_SIZE)? {
             Packet::TOpenRepository(req) => {
-                if req.protocol_version != "8" {
+                if req.protocol_version != CURRENT_REPOSITORY_PROTOCOL_VERSION {
                     anyhow::bail!(
-                        "server does not support bupstash protocol version {}",
-                        req.protocol_version
+                        "client and server protocol versions are incompatible, got {}, wanted {}",
+                        req.protocol_version,
+                        CURRENT_REPOSITORY_PROTOCOL_VERSION,
                     )
                 }
 

--- a/src/sodium.rs
+++ b/src/sodium.rs
@@ -2,5 +2,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
+#![allow(deref_nullptr)] // see https://github.com/rust-lang/rust-bindgen/issues/1651
 #![allow(clippy::redundant_static_lifetimes)]
 include!("./sodium_bindings_gen.rs");


### PR DESCRIPTION
This fixes a problem where new data would ruin deduplication
for the entire index... Unfortunately old backups can no
longer be used with --pick due to how data was structured.