### PR TITLE
Implement restore command and rename restore-removed to recover-removed.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
+ "walkdir",
  "xattr",
 ]
 
@@ -623,6 +624,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +832,17 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ rangemap = "0.1.11"
 xattr = "0.2"
 openat = "0.1"
 lazy_static = "1.4"
+walkdir = "2"
 
 [dev-dependencies]
 

--- a/cli-tests/parallel-thrash.sh
+++ b/cli-tests/parallel-thrash.sh
@@ -56,12 +56,12 @@ thrash_worker () {
       inc_result "put-fail"
     fi
 
-    bupstash restore-removed -q >&2
+    bupstash recover-removed -q >&2
     if test "$?" = 0
     then
-      inc_result "restore-removed-ok"
+      inc_result "recover-removed-ok"
     else
-      inc_result "restore-removed-fail"
+      inc_result "recover-removed-fail"
     fi
 
     bupstash gc -q >&2

--- a/cli-tests/s3-parallel-thrash.sh
+++ b/cli-tests/s3-parallel-thrash.sh
@@ -67,12 +67,12 @@ thrash_worker () {
       inc_result "put-fail"
     fi
 
-    bupstash restore-removed -q >&2
+    bupstash recover-removed -q >&2
     if test "$?" = 0
     then
-      inc_result "restore-removed-ok"
+      inc_result "recover-removed-ok"
     else
-      inc_result "restore-removed-fail"
+      inc_result "recover-removed-fail"
     fi
 
     bupstash gc -q >&2

--- a/doc/cli/diff.txt
+++ b/doc/cli/diff.txt
@@ -2,8 +2,8 @@ bupstash diff [OPTIONS] QUERY1 :: QUERY2
 
 Diff two snapshots.
 
-See the bupstash manual for a detauked description of diff semantics
+See the bupstash manual for a detailed description of diff semantics
 
 Examples:
-  $ bupstash diff id=8f7* :: id=def*
+  $ bupstash diff id="8f7*" :: id="def*"
   $ bupstash diff --relaxed id="57de*" :: ./files

--- a/doc/cli/gc.txt
+++ b/doc/cli/gc.txt
@@ -3,9 +3,9 @@ bupstash gc [OPTIONS]
 Run the garbage collector against a repository, removing
 unreferenced data and freeing disk space.
 
-'put' and 'get' operations will be blocked during periods while garbage collection
+Concurrent operations may be delayed while garbage collection
 is in progress.
 
 Examples:
-  $ bupstash gc -r ./backups
+  $ bupstash gc
   $ bupstash gc -r ssh://$server/repository

--- a/doc/cli/help.txt
+++ b/doc/cli/help.txt
@@ -12,8 +12,9 @@ Subcommands:
   list              List items in a repository.
   list-contents     List contents of a directory snapshot.
   get               Get data from a repository.
+  restore           Restore a snapshot to a local directory.
   rm/remove         Remove items from a repository.
-  restore-removed   Restore items pending garbage collection.
+  recover-removed   Recover items pending garbage collection.
   gc                Delete unreferenced data and free space.
   version           Print the version and exit.
   help              Print this message.

--- a/doc/cli/recover-removed.txt
+++ b/doc/cli/recover-removed.txt
@@ -1,0 +1,7 @@
+bupstash recover-removed [OPTIONS]
+
+Recover repository items that were removed, but that have not
+yet been deleted via garbage collection.
+
+Examples:
+  $ bupstash recover-removed -r ./backups

--- a/doc/cli/restore-removed.txt
+++ b/doc/cli/restore-removed.txt
@@ -1,7 +1,0 @@
-bupstash restore-removed [OPTIONS]
-
-Restore repository items that were removed, but that have not
-yet been deleted via garbage collection.
-
-Examples:
-  $ bupstash restore-removed -r ./backups

--- a/doc/cli/restore.txt
+++ b/doc/cli/restore.txt
@@ -1,0 +1,9 @@
+bupstash restore [OPTIONS] --into DIR QUERY
+
+Efficiently restore the contents of a snapshot into a local directory,
+deleting any extra files that already existed in that directory.
+
+Examples:
+  $ bupstash restore --into ./dir id="8f7*"
+  $ bupstash restore --pick sub-dir --into ./dir id="8f7*"
+  $ bupstash restore --ownership --into ./dir id="8f7*"

--- a/doc/guides/Getting Started.md
+++ b/doc/guides/Getting Started.md
@@ -161,7 +161,13 @@ drwxr-xr-x 0 2020/10/30 13:32:04 .
 ...
 ```
 
-We can also extract individual directories, subdirectories, or the whole snapshot.
+We can efficiently restore a snapshot to a local directory only downloading the files that are missing:
+```
+$ mkdir restore-dir
+$ bupstash restore --into ./restore-dir id=$id
+```
+
+We can also export individual files or directories as a tarballs:
 
 ```
 $ bupstash get --pick data.txt id=$id

--- a/doc/man/bupstash-gc.1.md
+++ b/doc/man/bupstash-gc.1.md
@@ -13,8 +13,8 @@ unreferenced data and freeing disk space.
 `bupstash gc` walks the repository contents attempting to find
 unreachable data chunks and removing them, potentially reclaiming disk space.
 
-For periods of time during garbage collection operations that modify
-the repository (such as bupstash-put(1)) may temporarily be blocked.
+It is safe to run `bupstash gc` at any time, but some operations (such as bupstash-put(1))
+may temporarily be delayed.
 
 The garbage collector only relies on unencrypted metadata, so does not need
 access to decryption keys to operate.

--- a/doc/man/bupstash-recover-removed.1.md
+++ b/doc/man/bupstash-recover-removed.1.md
@@ -1,21 +1,21 @@
-bupstash-restore-removed(1) 
+bupstash-recover-removed(1) 
 ==============
 
 ## SYNOPSIS
 
-Restore repository items that were removed, but that have not
+Recover repository items that were removed, but that have not
 yet been deleted via garbage collection.
 
-`bupstash restore-removed [OPTIONS]`
+`bupstash recover-removed [OPTIONS]`
 
 ## DESCRIPTION
 
-`bupstash restore-removed` allows a user to undo all 'rm' operations that
+`bupstash recover-removed` allows a user to undo all 'rm' operations that
 have taken place since the last invocation of bupstash-gc(1).
 In other words, this command provides a way to correct errors and accidental
 invocations of bupstash-rm(1).
 
-`bupstash restore-removed` requires 'put' and 'get' permissions for the repository being operated on.
+`bupstash recover-removed` requires 'put' and 'get' permissions for the repository being operated on.
 
 ## OPTIONS
 

--- a/doc/man/bupstash-repository.7.md
+++ b/doc/man/bupstash-repository.7.md
@@ -45,7 +45,7 @@ This file is an append only ledger where each entry is a [bare](https://baremess
 type Xid data<16>;
 type Address data<32>;
 
-type LogOp  (AddItem | RemoveItems);
+type LogOp  (AddItem | RemoveItems | RecoverRemoved);
   
 type AddItem {
   id: Xid
@@ -55,6 +55,8 @@ type AddItem {
 type RemoveItems {
   items: []Xid
 }
+
+type RemoveRemoved {}
 
 type VersionedItemMetadata = (V1VersionedItemMetadata | V2VersionedItemMetadata)
 
@@ -213,18 +215,20 @@ Valid compression flags are:
 
 ### Hash tree node chunk
 
-These chunks form non leaf nodes in our hash tree, and consist of an array of addresses.
+These chunks form non leaf nodes in our hash tree, they consist of an array of addresses prefixed
+with the total number of data chunks that are beneath them in the tree.
 
 ```
-ADDRESS[ADDRESS_SZ]
-ADDRESS[ADDRESS_SZ]
-ADDRESS[ADDRESS_SZ]
-ADDRESS[ADDRESS_SZ]
+NUM_DATA_CHUNKS[8] ADDRESS[ADDRESS_SZ]
+NUM_DATA_CHUNKS[8] ADDRESS[ADDRESS_SZ]
+NUM_DATA_CHUNKS[8] ADDRESS[ADDRESS_SZ]
+NUM_DATA_CHUNKS[8] ADDRESS[ADDRESS_SZ]
 ...
 ```
 
 These addresses must be recursively followed to read our data chunks, these addresses correspond
-to data chunks when the tree height is 0.
+to data chunks when the tree height is 0. The chunk counts can be used to efficiently seek to address offsets
+in the tree.
 
 ### Format of key exchange bytes
 

--- a/doc/man/bupstash-restore.1.md
+++ b/doc/man/bupstash-restore.1.md
@@ -1,18 +1,25 @@
-bupstash-get(1) 
-===============
+bupstash-restore(1) 
+================
 
 ## SYNOPSIS
 
-Get data from a bupstash repository.
+Efficiently restore the contents of a snapshot into a local directory.
 
-`bupstash get [OPTIONS] QUERY... `
+`bupstash restore [OPTIONS] --into $PATH QUERY... `
 
 ## DESCRIPTION
 
-`bupstash get` fetches and decrypts data stored in a bupstash repository, sending
-it to stdout.
+`bupstash restore` performs an efficient set of incremental changes to
+a directory such that it becomes identical to the requested snapshot.
+The incremental nature of `bupstash restore` makes it well suited for
+cycling between multiple similar snapshots. Note that this operation is dangerous
+as it deletes extra files already present in the destination directory.
 
-The item that is fetched is chosen based on a simple query against the 
+In order to aid file browsing as unprivileged users, `bupstash restore` does
+not attempt to restore users, groups and xattrs by default. To set
+these you must specify the flags --ownership and --xattrs respectively.
+
+The item that is checked out is chosen based on a simple query against the 
 tags specified when saving data with `bupstash put`.
 
 ## QUERY LANGUAGE
@@ -21,10 +28,13 @@ For full documentation on the query language, see bupstash-query-language(7).
 
 ## QUERY CACHING
 
-The get command uses the same query caching mechanisms as bupstash-list(1), check that page for
+The restore command uses the same query caching mechanisms as bupstash-list(1), check that page for
 more information on the query cache.
 
 ## OPTIONS
+
+* --into PATH:
+  Directory to restore files into, defaults to $BUPSTASH_CHECKOUT_DIR.
 
 * -r, --repository REPO:
   The repository to connect to, , may be of the form `ssh://$SERVER/$PATH` for
@@ -35,7 +45,13 @@ more information on the query cache.
   to `BUPSTASH_KEY`.
 
 * --pick PATH:
-  Fetch an individual file or sub-directory from a snapshot.
+  Pick a sub-directory of the snapshot to restore.
+
+* --ownership:
+  Set uid's and gid's.
+
+* --xattrs:
+  Set xattrs.
 
 * --query-cache PATH:
   Path to the query-cache file, defaults to one of the following, in order, provided
@@ -69,43 +85,29 @@ more information on the query cache.
 * BUPSTASH_QUERY_CACHE:
   Path to the query cache file to use.
 
+* BUPSTASH_RESTORE_DIR:
+  Path to restore into.
 
 ## EXAMPLES
 
-### Get an item with a specific id 
+### Restore a snapshot into a local directory
 
 ```
-$ bupstash get id=14ebd2073b258b1f55c5bbc889c49db4 > ./data.file
+$ bupstash restore --into ./dir id=ad8*
 ```
 
-### Get an item by name and timestamp
+### Restore including users and groups
 
 ```
-$ bupstash get name=backup.tar and timestamp=2020/19/* > ./restore.tar
+$ bupstash restore --ownership --into ./dir id=ad8*
 ```
 
-### Get a file or sub-tar from a directory snapshot
+### Restore a sub directory of the snapshot
 
 ```
-$ bupstash get --pick=path/to/file.txt id=$id
-$ bupstash get --pick=path/to/dir id=$id | tar ...
-```
-
-### Get a tarball
-
-The builtin directory put creates a tarball from a directory, so to extract 
-it we use tar.
-
-```
-# Snapshot a directory.
-$ id=$(bupstash put ./data)
-
-# Fetch the contents of a snapshot and extract the contents with tar
-$ mkdir restore
-$ bupstash get id=$id | tar -C ./restore -xvf -
+$ bupstash restore --into ./dir --pick sub/dir id=ad8*
 ```
 
 ## SEE ALSO
 
-bupstash(1), bupstash-put(1), bupstash-list(1), bupstash-restore(1), bupstash-rm(1), bupstash-keyfiles(7),
-bupstash-query-language(7)
+bupstash(1), bupstash-get(1), bupstash-list(1), bupstash-keyfiles(7), bupstash-query-language(7)

--- a/doc/man/bupstash.1.md
+++ b/doc/man/bupstash.1.md
@@ -15,8 +15,9 @@ Run one of the following `bupstash` subcommands.
 `bupstash list-contents ...`<br>
 `bupstash diff ...`<br>
 `bupstash get ...`<br>
+`bupstash restore ...`<br>
 `bupstash rm ...`<br>
-`bupstash restore-removed ...`<br>
+`bupstash recover-removed ...`<br>
 `bupstash gc ...`<br>
 `bupstash serve ...`<br>
 `bupstash help ...`<br>
@@ -53,6 +54,8 @@ that each have their own documentation.
   Add data to a bupstash repository.
 * bupstash-get(1):
   Fetch data from the bupstash repository matching a query.
+* bupstash-restore(1):
+  Restore a snapshot into a local directory.
 * bupstash-list(1):
   List repository items matching a given query.
 * bupstash-list-contents(1):
@@ -61,8 +64,8 @@ that each have their own documentation.
   Diff snapshot contents.
 * bupstash-rm(1):
   Remove repository items matching a given query.
-* bupstash-restore-removed(1):
-  Restore accidentally removed items.
+* bupstash-recover-removed(1):
+  Recover removed items that are pending garbage collection.
 * bupstash-gc(1):
   Reclaim diskspace in a repository.
 * bupstash-serve(1):
@@ -91,8 +94,8 @@ $ bupstash put ./some-data
 ebb66f3baa5d432e9f9a28934888a23d
 
 $ bupstash list-contents id=ebb66f3baa5d432e9f9a28934888a23d
-drwxr-xr-x 0      2020/11/05 10:42:48 .
--rw-r--r-- 1778   2020/07/12 17:13:42 data.txt
+drwxr-xr-x 0    2020/11/05 10:42:48 .
+-rw-r--r-- 177B 2020/07/12 17:13:42 data.txt
 ```
 
 ### List items matching a query
@@ -126,6 +129,12 @@ $ bupstash put --exec name=database.sql pgdump mydatabase
 ```
 $ bupstash get id=bcb8684e6bf5cb453e77486decf61685
 some data.
+```
+
+### Restore a directory to a previous snapshot
+
+```
+$ bupstash restore --to ./dir name=dir.tar
 ```
 
 ### Remove items matching a query.

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,10 +4,12 @@ use super::chunker;
 use super::compression;
 use super::crypto;
 use super::fprefetch;
+use super::fsutil;
 use super::fsutil::likely_smear_error;
 use super::htree;
 use super::index;
 use super::indexer;
+use super::ioutil;
 use super::oplog;
 use super::protocol::*;
 use super::querycache;
@@ -17,9 +19,13 @@ use super::sendlog;
 use super::xid::*;
 use super::xtar;
 use std::cell::{Cell, RefCell};
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
+use std::io::Read;
 use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 
 // These chunk parameters could be investigated and tuned.
 pub const CHUNK_MIN_SIZE: usize = 256 * 1024;
@@ -385,7 +391,7 @@ impl<'a, 'b, 'c> SendSession<'a, 'b, 'c> {
 
                         if index_ent.is_file() {
                             let mut f = match file_opener.next_file().unwrap() {
-                                (_, Ok(f)) => TeeHashFileReader::new(f),
+                                (_, Ok(f)) => ioutil::TeeReader::new(f, blake3::Hasher::new()),
 
                                 (_, Err(err)) if likely_smear_error(&err) => {
                                     // This can happen if the file was deleted,
@@ -408,7 +414,10 @@ impl<'a, 'b, 'c> SendSession<'a, 'b, 'c> {
                                 index_ent.size.0 = file_len;
                             }
 
-                            index_ent.data_hash = index::ContentCryptoHash::Blake3(f.finalize());
+                            let (_, file_hasher) = f.into_inner();
+
+                            index_ent.data_hash =
+                                index::ContentCryptoHash::Blake3(file_hasher.finalize().into());
                         }
 
                         if i == n_idx_ents - 1 {
@@ -508,7 +517,7 @@ impl<'a, 'b, 'c> SendSession<'a, 'b, 'c> {
             idx_tree_meta = Some(idx_tw.finish(&mut self)?);
         }
 
-        self.ctx.progress.set_message("syncing storage...");
+        self.ctx.progress.set_message("flushing storage...");
         self.sync()?;
 
         let stats = SendStats {
@@ -712,37 +721,6 @@ pub fn send(
     }
 }
 
-// Read a file while also blake3 hashing any data.
-struct TeeHashFileReader {
-    f: std::fs::File,
-    h: blake3::Hasher,
-}
-
-impl TeeHashFileReader {
-    fn new(f: std::fs::File) -> Self {
-        TeeHashFileReader {
-            f,
-            h: blake3::Hasher::new(),
-        }
-    }
-
-    fn finalize(self) -> [u8; 32] {
-        self.h.finalize().into()
-    }
-}
-
-impl std::io::Read for TeeHashFileReader {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        match self.f.read(buf) {
-            Ok(n) => {
-                self.h.update(&buf[0..n]);
-                Ok(n)
-            }
-            err => err,
-        }
-    }
-}
-
 pub fn request_metadata(
     id: Xid,
     r: &mut dyn std::io::Read,
@@ -771,16 +749,16 @@ pub fn request_data_stream(
     mut ctx: DataRequestContext,
     id: Xid,
     metadata: &oplog::VersionedItemMetadata,
-    pick: Option<index::PickMap>,
+    data_map: Option<index::DataMap>,
     index: Option<index::CompressedIndex>,
     r: &mut dyn std::io::Read,
     w: &mut dyn std::io::Write,
     out: &mut dyn std::io::Write,
 ) -> Result<(), anyhow::Error> {
     // It makes little sense to ask the server for an empty pick.
-    if let Some(ref pick) = pick {
-        if pick.data_chunk_ranges.is_empty() {
-            if let Some(ref index) = pick.index {
+    if let Some(ref data_map) = data_map {
+        if data_map.data_chunk_ranges.is_empty() {
+            if let Some(ref index) = index {
                 return write_indexed_data_as_tarball(&mut || Ok(None), index, out);
             } else {
                 return Ok(());
@@ -806,10 +784,19 @@ pub fn request_data_stream(
         &data_tree.address,
     );
 
-    match pick {
-        Some(pick) => {
+    match data_map {
+        Some(data_map) => {
             write_packet(w, &Packet::RequestData(RequestData { id, partial: true }))?;
-            receive_partial_htree(&mut ctx.data_dctx, &hash_key, r, w, &mut tr, pick, out)?;
+            receive_partial_htree(
+                &mut ctx.data_dctx,
+                &hash_key,
+                r,
+                w,
+                &mut tr,
+                data_map,
+                index,
+                out,
+            )?;
         }
         None => {
             write_packet(w, &Packet::RequestData(RequestData { id, partial: false }))?;
@@ -1066,24 +1053,26 @@ fn receive_indexed_htree_as_tarball(
     write_indexed_data_as_tarball(&mut read_data, index, out)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn receive_partial_htree(
     dctx: &mut crypto::DecryptionContext,
     hash_key: &crypto::HashKey,
     r: &mut dyn std::io::Read,
     w: &mut dyn std::io::Write,
     tr: &mut htree::TreeReader,
-    pick: index::PickMap,
+    data_map: index::DataMap,
+    index: Option<index::CompressedIndex>,
     out: &mut dyn std::io::Write,
 ) -> Result<(), anyhow::Error> {
     // This is avoided before we make a server request.
-    assert!(!pick.data_chunk_ranges.is_empty());
+    assert!(!data_map.data_chunk_ranges.is_empty());
 
     let mut data_addresses = VecDeque::with_capacity(64);
     let mut current_data_chunk_idx: u64 = 0;
     let mut range_idx: usize = 0;
 
     // We send ranges in groups to keep a bound on server memory usage.
-    let mut range_groups = pick
+    let mut range_groups = data_map
         .data_chunk_ranges
         // Test harsher range splits in debug mode.
         .chunks(if cfg!(debug_assertions) { 1 } else { 100000 });
@@ -1111,7 +1100,7 @@ fn receive_partial_htree(
                 if chunk_addr != crypto::keyed_content_address(&data, &hash_key) {
                     return Err(ClientError::CorruptOrTamperedData.into());
                 }
-                let data = match pick.incomplete_data_chunks.get(&current_data_chunk_idx) {
+                let data = match data_map.incomplete_data_chunks.get(&current_data_chunk_idx) {
                     Some(byte_ranges) => {
                         let mut filtered_data = Vec::with_capacity(data.len() / 2);
 
@@ -1187,7 +1176,7 @@ fn receive_partial_htree(
         }
     };
 
-    if let Some(ref index) = pick.index {
+    if let Some(ref index) = index {
         write_indexed_data_as_tarball(&mut read_data, index, out)?;
     } else {
         while let Some(data) = read_data()? {
@@ -1198,16 +1187,16 @@ fn receive_partial_htree(
     Ok(())
 }
 
-pub fn restore_removed(
+pub fn recover_removed(
     progress: indicatif::ProgressBar,
     r: &mut dyn std::io::Read,
     w: &mut dyn std::io::Write,
 ) -> Result<u64, anyhow::Error> {
-    progress.set_message("restoring items...");
+    progress.set_message("recovering items...");
 
-    write_packet(w, &Packet::TRestoreRemoved)?;
+    write_packet(w, &Packet::TRecoverRemoved)?;
     match read_packet(r, DEFAULT_MAX_PACKET_SIZE)? {
-        Packet::RRestoreRemoved(RRestoreRemoved { n_restored }) => Ok(n_restored.0),
+        Packet::RRecoverRemoved(RRecoverRemoved { n_recovered }) => Ok(n_recovered.0),
         _ => anyhow::bail!("protocol error, expected restore packet response or progress packet",),
     }
 }
@@ -1234,7 +1223,7 @@ pub fn gc(
     }
 }
 
-pub fn sync(
+pub fn sync_query_cache(
     progress: indicatif::ProgressBar,
     query_cache: &mut querycache::QueryCache,
     r: &mut dyn std::io::Read,
@@ -1296,6 +1285,434 @@ pub fn remove(
             _ => anyhow::bail!("protocol error, expected RRmItems"),
         }
     }
+    Ok(())
+}
+
+pub struct RestoreContext {
+    pub data_ctx: DataRequestContext,
+    pub item_id: Xid,
+    pub metadata: oplog::VersionedItemMetadata,
+    pub restore_xattrs: bool,
+    pub restore_ownership: bool,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn restore_to_local_dir(
+    progress: &indicatif::ProgressBar,
+    ctx: RestoreContext,
+    content_index: index::CompressedIndex,
+    data_map: Option<index::DataMap>,
+    serve_out: &mut dyn std::io::Read,
+    serve_in: &mut dyn std::io::Write,
+    to_dir: &Path,
+) -> Result<(), anyhow::Error> {
+    // Initially reset the permissions and groups on everything
+    // so we don't need to worry about read only files or other access.
+    progress.set_message("preparing directory...");
+    let uid = nix::unistd::Uid::effective();
+    let gid = nix::unistd::Gid::effective();
+    for dir_ent in walkdir::WalkDir::new(&to_dir) {
+        let dir_ent = dir_ent?;
+        let metadata = dir_ent.path().symlink_metadata()?;
+        if metadata.uid() != libc::uid_t::from(uid) || metadata.gid() != libc::uid_t::from(gid) {
+            match nix::unistd::fchownat(
+                None,
+                dir_ent.path(),
+                Some(uid),
+                Some(gid),
+                nix::unistd::FchownatFlags::NoFollowSymlink,
+            ) {
+                Ok(_) => (),
+                Err(err) => anyhow::bail!("failed to chown {}: {}", dir_ent.path().display(), err),
+            };
+        }
+
+        // Make any read only files writable for the later code...
+        if !metadata.file_type().is_symlink() && (metadata.permissions().mode() & 0o200 == 0) {
+            match nix::sys::stat::fchmodat(
+                None,
+                dir_ent.path(),
+                // What we use here doesn't really matter for sync, it gets fixed later...
+                nix::sys::stat::Mode::from_bits_truncate(0o700),
+                nix::sys::stat::FchmodatFlags::FollowSymlink,
+            ) {
+                Ok(_) => (),
+                Err(err) => anyhow::bail!(
+                    "failed to set permissions of {}: {}",
+                    dir_ent.path().display(),
+                    err
+                ),
+            };
+        }
+    }
+
+    let to_dir_index = {
+        progress.set_message(format!("indexing {}...", to_dir.to_string_lossy()));
+        let mut ciw = index::CompressedIndexWriter::new();
+        for indexed_dir in indexer::FsIndexer::new(
+            &[to_dir.to_owned()],
+            indexer::FsIndexerOptions {
+                exclusions: vec![],
+                want_xattrs: false,
+                want_hash: true,
+                one_file_system: false,
+            },
+        )? {
+            let indexed_dir = indexed_dir?;
+            for index_ent in indexed_dir.index_ents {
+                ciw.add(&index_ent);
+            }
+        }
+        ciw.finish()
+    };
+
+    progress.set_message("computing content diff...");
+    let mut to_remove = Vec::with_capacity(512);
+    let mut new_dirs = Vec::with_capacity(512);
+    let mut create_path_set = HashSet::with_capacity(512);
+    let mut create_index_writer = index::CompressedIndexWriter::new();
+    let mut download_index_path_set = HashSet::with_capacity(512);
+    let mut downloads = Vec::with_capacity(512);
+
+    {
+        index::diff(
+            &to_dir_index,
+            &content_index,
+            !(index::INDEX_COMPARE_MASK_TYPE
+                | index::INDEX_COMPARE_MASK_LINK_TARGET
+                | index::INDEX_COMPARE_MASK_DEVNOS
+                | index::INDEX_COMPARE_MASK_DATA_HASH),
+            &mut |ds: index::DiffStat, e: &index::IndexEntry| -> Result<(), anyhow::Error> {
+                match ds {
+                    index::DiffStat::Unchanged => (),
+                    index::DiffStat::Removed => {
+                        to_remove.push((PathBuf::from(&e.path), e.kind()));
+                    }
+                    index::DiffStat::Added => {
+                        if e.is_dir() {
+                            new_dirs.push(PathBuf::from(&e.path));
+                        } else if e.is_file() {
+                            download_index_path_set.insert(e.path.clone());
+                            downloads.push((e.path.clone(), e.size.0, e.data_hash));
+                        } else {
+                            create_path_set.insert(e.path.clone());
+                            create_index_writer.add(e);
+                        }
+                    }
+                }
+
+                Ok(())
+            },
+        )?;
+    }
+
+    progress.set_message("removing extra files...");
+    to_remove.reverse();
+    if !to_remove.is_empty() {
+        for (path, kind) in to_remove.drain(..) {
+            let mut to_delete = to_dir.to_owned();
+            to_delete.push(path);
+
+            match if kind.is_dir() {
+                std::fs::remove_dir(&to_delete)
+            } else {
+                std::fs::remove_file(&to_delete)
+            } {
+                Ok(_) => (),
+                Err(err) => anyhow::bail!("failed to remove {}: {}", to_delete.display(), err),
+            }
+        }
+    }
+    std::mem::drop(to_remove);
+
+    if !new_dirs.is_empty() {
+        progress.set_message("creating new directories...");
+        for dir_path in new_dirs.drain(..) {
+            let mut to_create = to_dir.to_owned();
+            to_create.push(dir_path);
+            std::fs::create_dir(to_create)?;
+        }
+    }
+    std::mem::drop(new_dirs);
+
+    if !download_index_path_set.is_empty() {
+        progress.set_message("fetching files...");
+
+        let mut fetch_data_map = index::data_map_for_predicate(&content_index, &|e| {
+            download_index_path_set.contains(&e.path)
+        })?;
+
+        if let Some(data_map) = data_map {
+            if let Some(start_range) = data_map.data_chunk_ranges.first() {
+                fetch_data_map.add_offset(start_range.start_idx.0);
+            }
+        }
+
+        let (mut r, mut w) = ioutil::buffered_pipe(3 * 1024 * 1024); // Sized to cover most packets in one allocation.
+
+        let to_dir = to_dir.to_owned();
+        let worker = std::thread::spawn(move || -> std::io::Result<()> {
+            let r = &mut r;
+            for (path, size, hash) in downloads.drain(..) {
+                let mut to_create = to_dir.to_owned();
+                to_create.push(&path);
+                let mut f = std::fs::File::create(to_create)?;
+                match hash {
+                    index::ContentCryptoHash::None => {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!("{} in content index missing hash", &path),
+                        ))
+                    }
+                    index::ContentCryptoHash::Blake3(expected_hash) => {
+                        let mut tee = ioutil::TeeReader::new(r.take(size), blake3::Hasher::new());
+                        let n = std::io::copy(&mut tee, &mut f)?;
+                        if n != size {
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                format!("content of {} is smaller than expected", &path),
+                            ));
+                        }
+                        let (_, hasher) = tee.into_inner();
+                        let actual_hash: [u8; 32] = hasher.finalize().into();
+                        if expected_hash != actual_hash {
+                            return Err(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                format!("content of {} did not match expected hash", &path),
+                            ));
+                        }
+                    }
+                }
+            }
+            Ok(())
+        });
+        let download_err = request_data_stream(
+            ctx.data_ctx,
+            ctx.item_id,
+            &ctx.metadata,
+            Some(fetch_data_map),
+            None,
+            serve_out,
+            serve_in,
+            &mut w,
+        );
+        let file_err = worker.join().unwrap();
+        match file_err {
+            Ok(()) => {
+                download_err?;
+            }
+            // Copying to the files failed, the error must be a download error.
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => {
+                download_err?;
+            }
+            Err(err) => return Err(err.into()),
+        };
+    }
+    std::mem::drop(download_index_path_set);
+
+    if !create_path_set.is_empty() {
+        progress.set_message("creating special files and devices...");
+        for ent in create_index_writer.finish().iter() {
+            let ent = ent?;
+            if !create_path_set.contains(&ent.path) {
+                continue;
+            }
+            let mut to_create = to_dir.to_owned();
+            to_create.push(&ent.path);
+
+            match ent.kind() {
+                index::IndexEntryKind::Symlink => {
+                    if ent.link_target.is_none() {
+                        anyhow::bail!("{} is missing a link target", ent.path);
+                    }
+                    match std::os::unix::fs::symlink(&ent.link_target.unwrap(), &to_create) {
+                        Ok(_) => (),
+                        Err(err) => anyhow::bail!(
+                            "failed to make symlink at {}: {}",
+                            to_create.display(),
+                            err
+                        ),
+                    }
+                }
+                index::IndexEntryKind::Fifo => {
+                    match nix::unistd::mkfifo(&to_create, nix::sys::stat::Mode::S_IRWXU) {
+                        Ok(_) => (),
+                        Err(err) => {
+                            anyhow::bail!("failed to make fifo at {}: {}", to_create.display(), err)
+                        }
+                    }
+                }
+                index::IndexEntryKind::Block => match nix::sys::stat::mknod(
+                    &to_create,
+                    nix::sys::stat::SFlag::S_IFBLK,
+                    nix::sys::stat::Mode::S_IRWXU,
+                    fsutil::makedev(ent.dev_major.0, ent.dev_minor.0),
+                ) {
+                    Ok(_) => (),
+                    Err(err) => anyhow::bail!(
+                        "failed to make block device at {}: {}",
+                        to_create.display(),
+                        err
+                    ),
+                },
+                index::IndexEntryKind::Char => match nix::sys::stat::mknod(
+                    &to_create,
+                    nix::sys::stat::SFlag::S_IFCHR,
+                    nix::sys::stat::Mode::S_IRWXU,
+                    fsutil::makedev(ent.dev_major.0, ent.dev_minor.0),
+                ) {
+                    Ok(_) => (),
+                    Err(err) => anyhow::bail!(
+                        "failed to make char device at {}: {}",
+                        to_create.display(),
+                        err
+                    ),
+                },
+                _ => (),
+            }
+        }
+    }
+    std::mem::drop(create_path_set);
+
+    let restore_ownership = ctx.restore_ownership;
+    let restore_xattrs = ctx.restore_xattrs;
+
+    let apply_ent_attrs = |to_ch: &Path, ent: &index::IndexEntry| -> Result<(), anyhow::Error> {
+        if restore_xattrs && (ent.is_file() || ent.is_dir()) {
+            match xattr::list(&to_ch) {
+                Ok(attrs) => {
+                    for attr in attrs {
+                        match xattr::remove(to_ch, attr) {
+                            Ok(()) => (),
+                            Err(err) => anyhow::bail!(
+                                "failed to list remove xattr from {}: {}",
+                                to_ch.display(),
+                                err
+                            ),
+                        }
+                    }
+                }
+                Err(err) => anyhow::bail!("failed to list xattrs for {}: {}", to_ch.display(), err),
+            }
+            if let Some(ref xattrs) = ent.xattrs {
+                for (attr, value) in xattrs.iter() {
+                    match xattr::set(to_ch, attr, value) {
+                        Ok(()) => (),
+                        Err(err) => anyhow::bail!(
+                            "failed to list remove xattr {} from {}: {}",
+                            attr,
+                            to_ch.display(),
+                            err
+                        ),
+                    }
+                }
+            }
+        }
+
+        if restore_ownership {
+            match nix::unistd::fchownat(
+                None,
+                to_ch,
+                Some(nix::unistd::Uid::from_raw(ent.uid.0 as u32)),
+                Some(nix::unistd::Gid::from_raw(ent.gid.0 as u32)),
+                nix::unistd::FchownatFlags::NoFollowSymlink,
+            ) {
+                Ok(_) => (),
+                Err(err) => anyhow::bail!("failed to chown {}: {}", to_ch.display(), err),
+            };
+        }
+
+        if !ent.is_symlink() {
+            match nix::sys::stat::fchmodat(
+                None,
+                to_ch,
+                nix::sys::stat::Mode::from_bits_truncate(ent.mode.0 as libc::mode_t),
+                nix::sys::stat::FchmodatFlags::FollowSymlink,
+            ) {
+                Ok(_) => (),
+                Err(err) => {
+                    anyhow::bail!("failed to set permissions of {}: {}", to_ch.display(), err)
+                }
+            };
+        }
+
+        Ok(())
+    };
+
+    let mut dirs_to_alter = Vec::with_capacity(512);
+    let mut hardlinks: HashMap<(u64, u64), PathBuf> = HashMap::new();
+
+    progress.set_message("setting file attributes...");
+    {
+        index::diff(
+            &to_dir_index,
+            &content_index,
+            !(index::INDEX_COMPARE_MASK_PERMS | index::INDEX_COMPARE_MASK_XATTRS),
+            &mut |ds: index::DiffStat, ent: &index::IndexEntry| -> Result<(), anyhow::Error> {
+                if matches!(ds, index::DiffStat::Removed) {
+                    // Nothing to do, removals already processed.
+                    return Ok(());
+                }
+
+                match ds {
+                    index::DiffStat::Unchanged | index::DiffStat::Added => {
+                        // Handle any hard links, we are a little dumb and just
+                        // recreate them each time even if they are unchanged,
+                        // but hard links are relatively rare we can improve this later if needed.
+                        if !ent.is_dir() && ent.nlink.0 > 1 {
+                            let mut to_ch = to_dir.to_owned();
+                            to_ch.push(&ent.path);
+                            let dev_ino = (ent.norm_dev.0, ent.ino.0);
+                            match hardlinks.get(&dev_ino) {
+                                None => {
+                                    hardlinks.insert(dev_ino, to_ch);
+                                }
+                                Some(first_path) => match std::fs::remove_file(&to_ch) {
+                                    Ok(_) => match std::fs::hard_link(first_path, &to_ch) {
+                                        Ok(_) => (),
+                                        Err(err) => anyhow::bail!(
+                                            "failed to hard link {} as {}: {}",
+                                            to_ch.display(),
+                                            first_path.display(),
+                                            err
+                                        ),
+                                    },
+                                    Err(err) => {
+                                        anyhow::bail!(
+                                            "failed to remove {}: {}",
+                                            to_ch.display(),
+                                            err
+                                        )
+                                    }
+                                },
+                            }
+                        }
+
+                        if matches!(ds, index::DiffStat::Added) {
+                            // Set the perms and xattrs of anything that changed.
+                            let mut to_ch = to_dir.to_owned();
+                            to_ch.push(&ent.path);
+                            if ent.is_dir() {
+                                dirs_to_alter.push((to_ch, ent.clone()));
+                            } else {
+                                apply_ent_attrs(&to_ch, ent)?;
+                            }
+                        }
+                    }
+                    index::DiffStat::Removed => (),
+                }
+
+                Ok(())
+            },
+        )?;
+    }
+
+    // Process dirs in reverse order to account for read only permissions.
+    while let Some((to_ch, ent)) = dirs_to_alter.pop() {
+        apply_ent_attrs(&to_ch, &ent)?
+    }
+    std::mem::drop(dirs_to_alter);
+
     Ok(())
 }
 

--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -336,3 +336,36 @@ pub fn likely_smear_error(err: &std::io::Error) -> bool {
         std::io::ErrorKind::NotFound | std::io::ErrorKind::InvalidInput
     )
 }
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "macos")] {
+        // XXX These functions need testing...
+        pub fn makedev(major: u64, minor: u64) -> libc::dev_t
+        {
+            ((major << 24) | minor) as libc::dev_t
+        }
+
+        pub fn dev_major(dev: u64) -> u64 {
+            return (dev >> 24) & 0xff
+        }
+
+        pub fn dev_minor(dev :u64) -> u64 {
+            dev & 0xffffff
+        }
+
+    } else {
+
+        pub fn makedev(major: u64, minor: u64) -> libc::dev_t {
+            unsafe { libc::makedev(major as libc::c_uint, minor as libc::c_uint) }
+        }
+
+        pub fn dev_major(dev: u64) -> u64 {
+            unsafe { libc::major(dev as libc::dev_t) as u64 }
+        }
+
+        pub fn dev_minor(dev: u64) -> u64 {
+            unsafe { libc::minor(dev as libc::dev_t) as u64 }
+        }
+
+    }
+}

--- a/src/ioutil.rs
+++ b/src/ioutil.rs
@@ -1,0 +1,114 @@
+use std::io::{self, BufRead, Read, Write};
+
+pub struct PipeReader {
+    receiver: crossbeam_channel::Receiver<Vec<u8>>,
+    buffer: Vec<u8>,
+    position: usize,
+}
+
+pub struct PipeWriter {
+    sender: crossbeam_channel::Sender<Vec<u8>>,
+    buffer: Vec<u8>,
+    size: usize,
+}
+
+pub fn buffered_pipe(write_buf_sz: usize) -> (PipeReader, PipeWriter) {
+    let (tx, rx) = crossbeam_channel::bounded(0);
+    let write_buf_sz = write_buf_sz.max(1);
+    (
+        PipeReader {
+            receiver: rx,
+            buffer: Vec::new(),
+            position: 0,
+        },
+        PipeWriter {
+            sender: tx,
+            buffer: Vec::with_capacity(write_buf_sz),
+            size: write_buf_sz,
+        },
+    )
+}
+
+fn epipe() -> io::Error {
+    io::Error::new(io::ErrorKind::BrokenPipe, "pipe closed")
+}
+
+impl BufRead for PipeReader {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        if self.position >= self.buffer.len() {
+            if let Ok(data) = self.receiver.recv() {
+                debug_assert!(!data.is_empty());
+                self.buffer = data;
+                self.position = 0;
+            }
+        }
+        Ok(&self.buffer[self.position..])
+    }
+
+    fn consume(&mut self, amt: usize) {
+        debug_assert!(self.buffer.len() - self.position >= amt);
+        self.position += amt
+    }
+}
+
+impl Read for PipeReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let internal = self.fill_buf()?;
+        let len = std::cmp::min(buf.len(), internal.len());
+        if len > 0 {
+            buf[..len].copy_from_slice(&internal[..len]);
+            self.consume(len);
+        }
+        Ok(len)
+    }
+}
+
+impl Write for PipeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let bytes_written = if (buf.len() + self.buffer.len()) > self.buffer.capacity() {
+            self.buffer.capacity() - self.buffer.len()
+        } else {
+            buf.len()
+        };
+        self.buffer.extend_from_slice(&buf[..bytes_written]);
+        if self.buffer.len() == self.buffer.capacity() {
+            self.flush()?;
+        }
+        Ok(bytes_written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if self.buffer.is_empty() {
+            Ok(())
+        } else {
+            let data = std::mem::replace(&mut self.buffer, Vec::with_capacity(self.size));
+            match self.sender.send(data) {
+                Ok(_) => Ok(()),
+                Err(_) => Err(epipe()),
+            }
+        }
+    }
+}
+
+pub struct TeeReader<R, W> {
+    read: R,
+    output: W,
+}
+
+impl<R, W> TeeReader<R, W> {
+    pub fn new(read: R, output: W) -> Self {
+        Self { read, output }
+    }
+
+    pub fn into_inner(self) -> (R, W) {
+        (self.read, self.output)
+    }
+}
+
+impl<R: Read, W: Write> Read for TeeReader<R, W> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.read.read(buf)?;
+        self.output.write_all(&buf[..n])?;
+        Ok(n)
+    }
+}

--- a/src/oplog.rs
+++ b/src/oplog.rs
@@ -190,7 +190,7 @@ pub enum LogOp {
     // This is because batch deleting is possible, but batch add makes less sense.
     RemoveItems(Vec<Xid>),
 
-    RestoreRemoved,
+    RecoverRemoved,
 }
 
 pub fn checked_serialize_metadata(md: &VersionedItemMetadata) -> Result<Vec<u8>, anyhow::Error> {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -117,8 +117,8 @@ pub struct Abort {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct RRestoreRemoved {
-    pub n_restored: serde_bare::Uint,
+pub struct RRecoverRemoved {
+    pub n_recovered: serde_bare::Uint,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -161,8 +161,8 @@ pub enum Packet {
     RRequestChunkData(Vec<u8>),
     Progress(Progress),
     Abort(Abort),
-    TRestoreRemoved,
-    RRestoreRemoved(RRestoreRemoved),
+    TRecoverRemoved,
+    RRecoverRemoved(RRecoverRemoved),
     RequestIndex(RequestIndex),
     TStorageWriteBarrier,
     RStorageWriteBarrier(SyncStats),
@@ -203,8 +203,8 @@ const PACKET_KIND_T_REQUEST_CHUNK_DATA: u8 = 20;
 const PACKET_KIND_R_REQUEST_CHUNK_DATA: u8 = 21;
 const PACKET_KIND_PROGRESS: u8 = 22;
 const PACKET_KIND_ABORT: u8 = 23;
-const PACKET_KIND_T_RESTORE_REMOVED: u8 = 24;
-const PACKET_KIND_R_RESTORE_REMOVED: u8 = 25;
+const PACKET_KIND_T_RECOVER_REMOVED: u8 = 24;
+const PACKET_KIND_R_RECOVER_REMOVED: u8 = 25;
 const PACKET_KIND_REQUEST_INDEX: u8 = 26;
 const PACKET_KIND_T_REQUEST_METADATA: u8 = 28;
 const PACKET_KIND_R_REQUEST_METADATA: u8 = 29;
@@ -347,8 +347,8 @@ pub fn read_packet_raw(
         PACKET_KIND_R_REQUEST_CHUNK_DATA => Packet::RRequestChunkData(buf),
         PACKET_KIND_PROGRESS => Packet::Progress(serde_bare::from_slice(&buf)?),
         PACKET_KIND_ABORT => Packet::Abort(serde_bare::from_slice(&buf)?),
-        PACKET_KIND_T_RESTORE_REMOVED => Packet::TRestoreRemoved,
-        PACKET_KIND_R_RESTORE_REMOVED => Packet::RRestoreRemoved(serde_bare::from_slice(&buf)?),
+        PACKET_KIND_T_RECOVER_REMOVED => Packet::TRecoverRemoved,
+        PACKET_KIND_R_RECOVER_REMOVED => Packet::RRecoverRemoved(serde_bare::from_slice(&buf)?),
         PACKET_KIND_STORAGE_CONNECT => Packet::StorageConnect(serde_bare::from_slice(&buf)?),
         PACKET_KIND_T_STORAGE_PREPARE_FOR_SWEEP => {
             Packet::TStoragePrepareForSweep(serde_bare::from_slice(&buf)?)
@@ -584,12 +584,12 @@ pub fn write_packet(w: &mut dyn std::io::Write, pkt: &Packet) -> Result<(), anyh
             send_hdr(w, PACKET_KIND_ABORT, b.len().try_into()?)?;
             write_to_remote(w, &b)?;
         }
-        Packet::TRestoreRemoved => {
-            send_hdr(w, PACKET_KIND_T_RESTORE_REMOVED, 0)?;
+        Packet::TRecoverRemoved => {
+            send_hdr(w, PACKET_KIND_T_RECOVER_REMOVED, 0)?;
         }
-        Packet::RRestoreRemoved(ref v) => {
+        Packet::RRecoverRemoved(ref v) => {
             let b = serde_bare::to_vec(&v)?;
-            send_hdr(w, PACKET_KIND_R_RESTORE_REMOVED, b.len().try_into()?)?;
+            send_hdr(w, PACKET_KIND_R_RECOVER_REMOVED, b.len().try_into()?)?;
             write_to_remote(w, &b)?;
         }
         Packet::StorageConnect(ref v) => {

--- a/src/querycache.rs
+++ b/src/querycache.rs
@@ -246,7 +246,7 @@ impl<'a> QueryCacheTx<'a> {
                         .execute("delete from Items where ItemId = ?;", [item_id])?;
                 }
             }
-            oplog::LogOp::RestoreRemoved => {
+            oplog::LogOp::RecoverRemoved => {
                 self.tx.execute(
                     "insert into ItemOpLog(LogOffset, OpData) values(?, ?);",
                     rusqlite::params![op_offset as i64, serialized_op],

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -513,7 +513,7 @@ impl Repo {
         Ok(())
     }
 
-    pub fn restore_removed(&mut self) -> Result<u64, anyhow::Error> {
+    pub fn recover_removed(&mut self) -> Result<u64, anyhow::Error> {
         self.alter_lock_mode(RepoLockMode::Shared)?;
 
         let mut txn = fstx::WriteTxn::begin(&self.repo_path)?;
@@ -539,7 +539,7 @@ impl Repo {
         }
 
         if n_restored != 0 {
-            let op = oplog::LogOp::RestoreRemoved;
+            let op = oplog::LogOp::RecoverRemoved;
             let serialized_op = serde_bare::to_vec(&op)?;
             txn.add_append("repo.oplog", serialized_op)?;
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -123,15 +123,15 @@ fn serve_repository(
                 }
                 write_packet(w, &Packet::RRmItems)?;
             }
-            Packet::TRestoreRemoved => {
+            Packet::TRecoverRemoved => {
                 if !cfg.allow_get || !cfg.allow_put || !cfg.allow_list {
-                    anyhow::bail!("server has disabled restore for this client (restore requires get, put and list permissions).")
+                    anyhow::bail!("server has disabled recover-removed for this client (recover-removed requires get, put and list permissions).")
                 }
-                let n_restored = repo.restore_removed()?;
+                let n_recovered = repo.recover_removed()?;
                 write_packet(
                     w,
-                    &Packet::RRestoreRemoved(RRestoreRemoved {
-                        n_restored: serde_bare::Uint(n_restored),
+                    &Packet::RRecoverRemoved(RRecoverRemoved {
+                        n_recovered: serde_bare::Uint(n_recovered),
                     }),
                 )?;
             }


### PR DESCRIPTION
This change implements the restore command to easily and efficiently
restore a directory to a snapshot.

restore-removed was renamed to recover-removed to help disambiguate this
less frequently used command from the new command.