### PR TITLE
Item id and metadata version are now included in plain text metadata

### DIFF
--- a/doc/man/bupstash-repository.7.md
+++ b/doc/man/bupstash-repository.7.md
@@ -58,13 +58,17 @@ type RemoveItems {
 
 type RemoveRemoved {}
 
-type VersionedItemMetadata = (V1VersionedItemMetadata | V2VersionedItemMetadata)
+type VersionedItemMetadata = (V1VersionedItemMetadata | V2VersionedItemMetadata | V2VersionedItemMetadata)
 
 type V1VersionedItemMetadata {
-  // deprecated in bupstash version 0.9
+  // deprecated
 }
 
 type V2VersionedItemMetadata {
+  // deprecated
+}
+
+type V3VersionedItemMetadata {
   primary_key_id: Xid,
   unix_timestamp_millis: u64,
   tree_height: usize,
@@ -72,7 +76,7 @@ type V2VersionedItemMetadata {
   encryped_metadata: data
 }
 
-struct V2SecretItemMetadata {
+struct V3SecretItemMetadata {
   plain_text_hash: data<32>
   send_key_id: Xid,
   hash_key_part_2: data<32>,

--- a/src/fstx.rs
+++ b/src/fstx.rs
@@ -453,6 +453,14 @@ impl WriteTxn {
         self.dirf.metadata(p)
     }
 
+    pub fn file_exists(&self, p: &str) -> Result<bool, std::io::Error> {
+        match self.dirf.metadata(p) {
+            Ok(_) => Ok(true),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
     pub fn read_dir(&self, p: &str) -> Result<openat::DirIter, std::io::Error> {
         self.dirf.list_dir(p)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -732,6 +732,9 @@ fn list_main(args: Vec<String>) -> Result<(), anyhow::Error> {
                         oplog::VersionedItemMetadata::V2(ref metadata) => {
                             Some(metadata.plain_text_metadata.unix_timestamp_millis)
                         }
+                        oplog::VersionedItemMetadata::V3(ref metadata) => {
+                            Some(metadata.plain_text_metadata.unix_timestamp_millis)
+                        }
                     };
                     if let Some(unix_timestamp_millis) = unix_timestamp_millis {
                         write!(out, ",\"unix_timestamp_millis\":{}", unix_timestamp_millis)?;

--- a/src/querycache.rs
+++ b/src/querycache.rs
@@ -320,7 +320,7 @@ impl<'a> QueryCacheTx<'a> {
                 && opts.primary_key_id.unwrap() == *metadata.primary_key_id()
             {
                 let mut dmetadata =
-                    metadata.decrypt_metadata(opts.metadata_dctx.as_mut().unwrap())?;
+                    metadata.decrypt_metadata(&item_id, opts.metadata_dctx.as_mut().unwrap())?;
 
                 // Add special builtin tags.
                 dmetadata.tags.insert("id".to_string(), item_id.to_string());

--- a/src/server.rs
+++ b/src/server.rs
@@ -181,7 +181,7 @@ fn recv(
                 }
 
                 match add_item.item {
-                    oplog::VersionedItemMetadata::V2(ref md) => {
+                    oplog::VersionedItemMetadata::V3(ref md) => {
                         let item_skew = (md.plain_text_metadata.unix_timestamp_millis as i64)
                             - chrono::Utc::now().timestamp_millis();
                         const MAX_SKEW_MINS: i64 = 15;
@@ -193,11 +193,11 @@ fn recv(
                         }
                     }
 
-                    _ => anyhow::bail!("server refusing item with incorrect metadata version"),
+                    _ => anyhow::bail!("server refusing new item with outdated metadata version"),
                 }
 
-                let item_id = repo.add_item(add_item.gc_generation, add_item.item)?;
-                write_packet(w, &Packet::RAddItem(item_id))?;
+                repo.add_item(add_item.gc_generation, add_item.id, add_item.item)?;
+                write_packet(w, &Packet::RAddItem)?;
                 break;
             }
             _ => anyhow::bail!("protocol error, unexpected packet"),


### PR DESCRIPTION
The client generates the item id now and it is hashed into the
metadata in order prevents the server from swapping which metadata
corresponds to a given item id.