### PR TITLE
Add --verbose, --no-progress --print-file-actions options.

### DIFF
--- a/doc/man/bupstash-diff.1.md
+++ b/doc/man/bupstash-diff.1.md
@@ -71,9 +71,12 @@ more information on the query cache.
 * --utc-timestamps:
   Display and search against timestamps in utc time instead of local time.
 
-* -q, --quiet:
+* --no-progress:
   Suppress progress indicators (Progress indicators are also suppressed when stderr
   is not an interactive terminal).
+
+* -q, --quiet:
+  Be quiet, implies --no-progress.
 
 ## ENVIRONMENT
 

--- a/doc/man/bupstash-gc.1.md
+++ b/doc/man/bupstash-gc.1.md
@@ -26,9 +26,13 @@ access to decryption keys to operate.
   May be of the form `ssh://$SERVER/$PATH` for 
   remote repositories if ssh access is configured.
   If not specified, is set to `BUPSTASH_REPOSITORY`.
-* -q, --quiet:
+
+* --no-progress:
   Suppress progress indicators (Progress indicators are also suppressed when stderr
   is not an interactive terminal).
+
+* -q, --quiet:
+  Be quiet, implies --no-progress.
 
 ## ENVIRONMENT
 

--- a/doc/man/bupstash-get.1.md
+++ b/doc/man/bupstash-get.1.md
@@ -42,12 +42,15 @@ more information on the query cache.
   the appropriate environment variables are set, `$BUPSTASH_QUERY_CACHE`,
   `$XDG_CACHE_HOME/.cache/bupstash/bupstash.qcache` or `$HOME/.cache/bupstash/bupstash.qcache`.
 
-* -q, --quiet:
+* --utc-timestamps:
+  Display and search against timestamps in utc time instead of local time.
+
+* --no-progress:
   Suppress progress indicators (Progress indicators are also suppressed when stderr
   is not an interactive terminal).
 
-* --utc-timestamps:
-  Display and search against timestamps in utc time instead of local time.
+* -q, --quiet:
+  Be quiet, implies --no-progress.
 
 ## ENVIRONMENT
 

--- a/doc/man/bupstash-list-contents.1.md
+++ b/doc/man/bupstash-list-contents.1.md
@@ -84,15 +84,18 @@ more information on the query cache.
   the appropriate environment variables are set, `$BUPSTASH_QUERY_CACHE`,
   `$XDG_CACHE_HOME/.cache/bupstash/bupstash.qcache` or `$HOME/.cache/bupstash/bupstash.qcache`.
 
-* -q, --quiet:
-  Suppress progress indicators (Progress indicators are also suppressed when stderr
-  is not an interactive terminal).
-
 * --pick PATH:
   List a sub-directory of the query.
 
 * --utc-timestamps:
   Display and search against timestamps in utc time instead of local time.
+
+  * --no-progress:
+  Suppress progress indicators (Progress indicators are also suppressed when stderr
+  is not an interactive terminal).
+
+* -q, --quiet:
+  Be quiet, implies --no-progress.
 
 ## ENVIRONMENT
 

--- a/doc/man/bupstash-list.1.md
+++ b/doc/man/bupstash-list.1.md
@@ -133,12 +133,15 @@ If --query-encrypted is specified, encrypted tags and metadata are omitted.
 * --format FORMAT:
   Set output format to one of the following 'human', 'jsonl'.
 
-* -q, --quiet:
+* --utc-timestamps:
+  Display and search against timestamps in utc time instead of local time.
+
+* --no-progress:
   Suppress progress indicators (Progress indicators are also suppressed when stderr
   is not an interactive terminal).
 
-* --utc-timestamps:
-  Display and search against timestamps in utc time instead of local time.
+* -q, --quiet:
+  Be quiet, implies --no-progress.
 
 ## ENVIRONMENT
 

--- a/doc/man/bupstash-put.1.md
+++ b/doc/man/bupstash-put.1.md
@@ -96,6 +96,44 @@ The following tags are reserved and cannot be set manually:
 - size
 - timestamp
 
+### File actions
+
+`bupstash put` will print a line to stderr for each directory entry
+processed when the --print-file-actions option is set.
+
+Each output line has the form:
+
+```
+$action $type $PATH
+```
+
+With possible actions:
+
+- `+` A file was added to the snapshot.
+- `~` A stat cache hit let us skip sending a file.
+- `x` A path was excluded from the snapshot due to an exclusion rule.
+
+With possible types:
+
+- `f` file
+- `l` symlink
+- `c` char device
+- `b` block device
+- `d` directory
+- `p` fifo
+
+### TIPS
+
+- `bupstash put` deduplicates and compresses data automatically, so avoid putting compressed
+  or encrypted data if you want optimal deduplication and compression. 
+
+- Combine `bupstash serve --allow-put` with ssh force commands to create restricted ssh keys that can
+  only add new backups but not list or remove old ones.
+
+- The difference between piping `tar` command output into `bupstash put`, and using `bupstash put` directly
+  on a directory, is the latter is able to use a send log and avoid reading files that has already
+  been sent to the server, and is able to create a snapshot listing for other commands like bupstash-list-contents(1).
+
 ## OPTIONS
 
 * -r, --repository REPO:
@@ -141,12 +179,21 @@ The following tags are reserved and cannot be set manually:
 * --xattrs:
   Save directory entry xattrs, only used when saving a directory.
 
+* --print-file-actions:
+  Print file actions in the form '$a $t $path' to stderr when processing directories, the section 'File Actions' for details.
+
 * --print-stats:
   Print put statistics to stderr on completion.
 
-* -q, --quiet:
+* --no-progress:
   Suppress progress indicators (Progress indicators are also suppressed when stderr
   is not an interactive terminal).
+
+* -q, --quiet:
+  Be quiet, implies --no-progress.
+
+* -v, --verbose:
+  Be verbose, implies --print-file-actions and --print-stats.
 
 ## ENVIRONMENT
 
@@ -214,18 +261,6 @@ $ bupstash put --exec name=dbdump.sql pgdump mydb
 $ export BUPSTASH_REPOSITORY_COMMAND="ssh -F ./my-ssh-config me@$SERVER bupstash serve /my/repo"
 $ bupstash put ./files
 ```
-
-## TIPS
-
-- `bupstash put` deduplicates and compresses data automatically, so avoid putting compressed
-  or encrypted data if you want optimal deduplication and compression. 
-
-- Combine `bupstash serve --allow-put` with ssh force commands to create restricted ssh keys that can
-  only add new backups but not list or remove old ones.
-
-- The difference between piping `tar` command output into `bupstash put`, and using `bupstash put` directly
-  on a directory, is the latter is able to use a send log and avoid reading files that has already
-  been sent to the server, and is able to create a snapshot listing for use with bupstash-list-contents(1).
 
 ## SEE ALSO
 

--- a/doc/man/bupstash-recover-removed.1.md
+++ b/doc/man/bupstash-recover-removed.1.md
@@ -24,9 +24,13 @@ invocations of bupstash-rm(1).
   May be of the form `ssh://$SERVER/$PATH` for 
   remote repositories if ssh access is configured.
   If not specified, is set to `BUPSTASH_REPOSITORY`.
-* -q, --quiet:
+
+* --no-progress:
   Suppress progress indicators (Progress indicators are also suppressed when stderr
   is not an interactive terminal).
+
+* -q, --quiet:
+  Be quiet, implies --no-progress.
 
 ## ENVIRONMENT
 

--- a/doc/man/bupstash-restore.1.md
+++ b/doc/man/bupstash-restore.1.md
@@ -58,12 +58,15 @@ more information on the query cache.
   the appropriate environment variables are set, `$BUPSTASH_QUERY_CACHE`,
   `$XDG_CACHE_HOME/.cache/bupstash/bupstash.qcache` or `$HOME/.cache/bupstash/bupstash.qcache`.
 
-* -q, --quiet:
+* --utc-timestamps:
+  Display and search against timestamps in utc time instead of local time.
+
+* --no-progress:
   Suppress progress indicators (Progress indicators are also suppressed when stderr
   is not an interactive terminal).
 
-* --utc-timestamps:
-  Display and search against timestamps in utc time instead of local time.
+* -q, --quiet:
+  Be quiet, implies --no-progress.
 
 ## ENVIRONMENT
 

--- a/doc/man/bupstash-rm.1.md
+++ b/doc/man/bupstash-rm.1.md
@@ -69,12 +69,15 @@ more information on the query cache.
   By default bupstash refuses to remove multiple items from a single query, this flag
   disables that safety feature.
 
-* -q, --quiet:
+* --utc-timestamps:
+  Display and search against timestamps in utc time instead of local time.
+
+* --no-progress:
   Suppress progress indicators (Progress indicators are also suppressed when stderr
   is not an interactive terminal).
 
-* --utc-timestamps:
-  Display and search against timestamps in utc time instead of local time.
+* -q, --quiet:
+  Be quiet, implies --no-progress.
 
 ## ENVIRONMENT
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -205,6 +205,18 @@ impl IndexEntry {
             || (self.mode.0 as libc::mode_t & libc::S_IFMT) == libc::S_IFCHR
     }
 
+    pub fn type_display_char(&self) -> char {
+        match self.kind() {
+            IndexEntryKind::Other => '?',
+            IndexEntryKind::Regular => 'f',
+            IndexEntryKind::Symlink => 'l',
+            IndexEntryKind::Char => 'c',
+            IndexEntryKind::Block => 'b',
+            IndexEntryKind::Directory => 'd',
+            IndexEntryKind::Fifo => 'p',
+        }
+    }
+
     pub fn display_mode(&self) -> String {
         let mode = self.mode.0 as libc::mode_t;
 


### PR DESCRIPTION
The main motivation of this commit is the new --print-file-actions
option for bupstash put. A secondary effect is tidying the output
control options by adding --no-progress to most commands.