### PR TITLE
OpenBSD: Implement makedev(), dev_major() and dev_minor()

### DIFF
--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -353,6 +353,20 @@ cfg_if::cfg_if! {
             dev & 0xffffff
         }
 
+    } else if #[cfg(target_os = "openbsd")] {
+
+        pub fn makedev(major: u64, minor: u64) -> libc::dev_t {
+            (((major & 0xff) << 8) | (minor & 0xff) | ((minor & 0xffff00) << 8)) as libc::dev_t
+        }
+
+        pub fn dev_major(dev: u64) -> u64 {
+            (dev >> 8) & 0xff
+        }
+
+        pub fn dev_minor(dev :u64) -> u64 {
+            (dev & 0xff) | ((dev & 0xffff0000) >> 8)
+        }
+
     } else {
 
         pub fn makedev(major: u64, minor: u64) -> libc::dev_t {


### PR DESCRIPTION
Commit 397284cc breaks building on OpenBSD:

```
error[E0425]: cannot find function `makedev` in crate `libc`
   --> src/fsutil.rs:359:28
    |
359 |             unsafe { libc::makedev(major as libc::c_uint, minor as libc::c_uint) }
    |                            ^^^^^^^ not found in `libc`

error[E0425]: cannot find function `major` in crate `libc`
   --> src/fsutil.rs:363:28
    |
363 |             unsafe { libc::major(dev as libc::dev_t) as u64 }
    |                            ^^^^^ not found in `libc`

error[E0425]: cannot find function `minor` in crate `libc`
   --> src/fsutil.rs:367:28
    |
367 |             unsafe { libc::minor(dev as libc::dev_t) as u64 }
    |                            ^^^^^ not found in `libc`

error: aborting due to 3 previous errors
```

Fix is similar to #104. Logic is based on
https://github.com/openbsd/src/blob/master/sys/sys/types.h#L211-L214

Tested by `put` and `restore` of `/dev`.