### PR TITLE
'list' command: Move stray '}' in jsonl1 output up.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -755,7 +755,7 @@ fn list_main(args: Vec<String>) -> Result<(), anyhow::Error> {
                             serde_json::to_string(&v)?
                         )?;
                     }
-                    writeln!(out, "}}")?;
+                    write!(out, "}}")?;
                     writeln!(out, "}}")?;
                 }
                 ListFormat::Bare => anyhow::bail!("unsupported list format"),


### PR DESCRIPTION
The closing brace of each list entry came in a separate line from the
closing brace of the 'tags' field, resulting in a format like this:

    {"id":"...", ..., "tags":{ ... }
    }
    {"id":"...", ..., "tags":{ ... }
    }
    {"id":"...", ..., "tags":{ ... }
    }

instead of the expected:

    {"id":"...", ..., "tags":{ ... }}
    {"id":"...", ..., "tags":{ ... }}
    {"id":"...", ..., "tags":{ ... }}

This patch moves the final brace up, resulting in the expected
one-JSON-record-per-line format.