### PR TITLE
Exclude improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Install bash automated test framework and run the following to run both the unit
 ```
 $ cargo test
 $ cargo build --release
-$ export PATH=`pwd`/target/release:$PATH
+$ export PATH=${CARGO_TARGET_DIR:-$PWD/target}/release:$PATH
 $ bats ./cli-tests
 ```
 

--- a/doc/guides/Filesystem Backups.md
+++ b/doc/guides/Filesystem Backups.md
@@ -49,7 +49,7 @@ Some points to consider about this snapshot method:
 
 - The use of --exclude to omit the user cache directories, we can save a lot of space in backups by ignoring things
   like out web browser cache, at the expense of less complete backups. You can specify --exclude more than once to
-  skip more than one directory or file.
+  skip more than one directory or file. See the man page for more details.
 
 - Bupstash incremental backups work best when the send log file used was last used for a snapshot of the same or similar input data.
   Manually specifying a send log path with --send-log ensures subsequent similar snapshots use the same send log, often dramatically increasing efficiency.

--- a/doc/man/bupstash-put.1.md
+++ b/doc/man/bupstash-put.1.md
@@ -160,6 +160,11 @@ With possible types:
   number of levels, `?` matches a single character, `[…]` matches a single character from
   a given character set (and can also be used to escape the other special characters: `[?]`).
 
+* --exclude-if-present FILENAME:
+  Exclude a directory's content if it contains a file with the given name. May be passed multiple times.
+  This will still backup the folder itself, containing the marker file. Common marker file names are `CACHEDIR.TAG`, `.backupexclude`
+  or `.no-backup`.
+
 * --send-log PATH:
   Path to the send log file, defaults to one of the following, in order, provided
   the appropriate environment variables are set, `$BUPSTASH_SEND_LOG`,

--- a/doc/man/bupstash-put.1.md
+++ b/doc/man/bupstash-put.1.md
@@ -151,9 +151,14 @@ With possible types:
 
 * --exclude PATTERN:
   Add an exclusion glob pattern to filter entries from the resulting tarball.
-  The glob is matched against the absolute path of the directory entry.
   This option may be passed multiple times, and is ignored if not
   uploading a directory snapshot.
+  The glob is matched against the absolute path of the directory entry.
+  It thus must start with a `/` and not end on one. It must also be normalized.
+  Globs without any slash are treated as file name matches, i.e. they are automatically prepended with `/**/`.
+  Usual globbing rules apply: `*` matches everything on a level, `**` matches any
+  number of levels, `?` matches a single character, `[…]` matches a single character from
+  a given character set (and can also be used to escape the other special characters: `[?]`).
 
 * --send-log PATH:
   Path to the send log file, defaults to one of the following, in order, provided

--- a/doc/man/bupstash-put.1.md
+++ b/doc/man/bupstash-put.1.md
@@ -153,9 +153,8 @@ With possible types:
   Add an exclusion glob pattern to filter entries from the resulting tarball.
   This option may be passed multiple times, and is ignored if not
   uploading a directory snapshot.
-  The glob is matched against the absolute path of the directory entry.
-  It thus must start with a `/` and not end on one. It must also be normalized.
-  Globs without any slash are treated as file name matches, i.e. they are automatically prepended with `/**/`.
+  The glob is matched against the absolute paths and should not end with a `/`.
+  Globs without a leading `/` or `**/` are treated as file name matches, i.e. they are automatically prepended with `**/`.
   Usual globbing rules apply: `*` matches everything on a level, `**` matches any
   number of levels, `?` matches a single character, `[…]` matches a single character from
   a given character set (and can also be used to escape the other special characters: `[?]`).

--- a/src/client.rs
+++ b/src/client.rs
@@ -310,6 +310,7 @@ impl<'a, 'b, 'c> SendSession<'a, 'b, 'c> {
         &mut self,
         paths: Vec<std::path::PathBuf>,
         exclusions: Vec<glob::Pattern>,
+        exclusion_markers: std::collections::HashSet<std::ffi::OsString>,
     ) -> Result<(), anyhow::Error> {
         let use_stat_cache = self.ctx.use_stat_cache;
 
@@ -322,6 +323,7 @@ impl<'a, 'b, 'c> SendSession<'a, 'b, 'c> {
                 want_xattrs: self.ctx.want_xattrs,
                 want_hash: false,
                 exclusions,
+                exclusion_markers,
             },
         )?
         .background();
@@ -601,6 +603,7 @@ pub enum DataSource {
     Filesystem {
         paths: Vec<std::path::PathBuf>,
         exclusions: Vec<glob::Pattern>,
+        exclusion_markers: std::collections::HashSet<std::ffi::OsString>,
     },
 }
 
@@ -709,8 +712,12 @@ pub fn send(
             ctx.progress.set_message(description);
             session.write_data(&mut data, &mut |_: &Address, _: usize| {})?;
         }
-        DataSource::Filesystem { paths, exclusions } => {
-            session.send_dir(paths, exclusions)?;
+        DataSource::Filesystem {
+            paths,
+            exclusions,
+            exclusion_markers,
+        } => {
+            session.send_dir(paths, exclusions, exclusion_markers)?;
         }
     }
 
@@ -1442,6 +1449,7 @@ pub fn restore_to_local_dir(
             &[to_dir.to_owned()],
             indexer::FsIndexerOptions {
                 exclusions: vec![],
+                exclusion_markers: HashSet::new(),
                 want_xattrs: false,
                 want_hash: true,
                 one_file_system: false,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -445,7 +445,14 @@ impl FsIndexer {
 
         dir_ent_paths.retain(|p| {
             for excl in self.opts.exclusions.iter() {
-                if excl.matches_path(p) {
+                if excl.matches_path_with(
+                    p,
+                    glob::MatchOptions {
+                        case_sensitive: false,
+                        require_literal_separator: true,
+                        require_literal_leading_dot: false,
+                    },
+                ) {
                     excluded_paths.push(p.to_owned());
                     return false;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -921,8 +921,8 @@ fn put_main(args: Vec<String>) -> Result<(), anyhow::Error> {
         }
 
         /* This check is technically redundant, but it gives a nicer error message. */
-        if e.starts_with("./") {
-            anyhow::bail!("No relative paths in --exclude");
+        if e.starts_with("./") || e.starts_with("../") {
+            anyhow::bail!("relative paths are not allowed in --exclude patterns");
         }
 
         /* Start with a / to match a path, and leave out slashes to match any file. */
@@ -937,7 +937,7 @@ fn put_main(args: Vec<String>) -> Result<(), anyhow::Error> {
             );
         } else {
             /* Just a file name */
-            e = format!("/**/{}", e);
+            e = format!("**/{}", e);
         }
 
         /* Check for unnormalized segments, as they too won't match anything. Skip this

--- a/src/main.rs
+++ b/src/main.rs
@@ -840,7 +840,9 @@ fn put_main(args: Vec<String>) -> Result<(), anyhow::Error> {
     opts.optmulti(
         "",
         "exclude",
-        "Exclude directory entries matching the given glob pattern when saving a directory, may be passed multiple times.",
+        "Exclude directory entries matching the given glob pattern when saving a directory, may be passed multiple times.\
+        Paths are absolute as they are currently mounted, and must start with a slash and not end on one even for directories.\
+        Patterns without any slashes will match any file (`--exclude foo` is equivalent to `--exclude '/**/foo'`).",
         "PATTERN",
     );
     opts.optflag(
@@ -899,11 +901,40 @@ fn put_main(args: Vec<String>) -> Result<(), anyhow::Error> {
         !(matches.opt_present("no-stat-caching") || matches.opt_present("no-send-log"));
 
     let mut exclusions = Vec::new();
-    for e in matches.opt_strs("exclude") {
-        match glob::Pattern::new(&e) {
-            Ok(pattern) => exclusions.push(pattern),
-            Err(err) => anyhow::bail!("--exclude option {:?} is not a valid glob: {}", e, err),
+    for mut e in matches.opt_strs("exclude") {
+        /* Sanity checks. Beware, the order of the checks matters */
+
+        /* An exclude path ending on / won't match anything. */
+        if e.ends_with('/') {
+            anyhow::bail!("--exclude option '{}' ends with '/', so it won't match anything", e);
         }
+        
+        /* This check is technically redundant, but it gives a nicer error message. */
+        if e.starts_with("./") {
+            anyhow::bail!("No relative paths in --exclude");
+        }
+
+        /* Start with a / to match a path, and leave out slashes to match any file. */
+        if e.starts_with('/') {
+            /* pass */
+        } else if e.contains('/') {
+            anyhow::bail!("--exclude option '{}' must start with a '/'", e);
+        } else {
+            /* Just a file name */
+            e = format!("/**/{}", e);
+        }
+
+        /* Check for unnormalized segments, as they too won't match anything 
+         * Note that this may interfere with range syntax: `[/./]`. However, these would make no
+         * sense as a range because each character is only given once.
+         */
+        if e.contains("/./") || e.contains("/../") || e.ends_with("/.") || e.ends_with("/..") {
+            anyhow::bail!("--exclude option '{}' must be normalized (no '.' and '..' segments)", e);
+        }
+
+        let pattern = glob::Pattern::new(&e)
+            .map_err(|err| anyhow::format_err!("--exclude option '{}' is not a valid glob: {}", e, err))?;
+        exclusions.push(pattern);
     }
 
     let one_file_system = matches.opt_present("one-file-system");


### PR DESCRIPTION
A number of changes:

- Add the --exclude-if-present option for skipping directory contents based on a marker file.
- Allow exclusions of the form `*.bak`, these are implicitly the same as `**/*.bak`.
- Better error messages for excludes that will never match anything.
- Better documentation.
