### PR TITLE
Improve support for non utf8 paths.

### DIFF
--- a/doc/man/bupstash-list-contents.1.md
+++ b/doc/man/bupstash-list-contents.1.md
@@ -37,7 +37,7 @@ Each line has the following json schema:
 
 ```
 {
-  "path": string,
+  "path": string | [ bytes... ],
   "mode": number,
   "size": number,
   "uid": number,
@@ -52,7 +52,7 @@ Each line has the following json schema:
   "link_target": string | null,
   "dev_major": number | null,
   "dev_minor": number | null,
-  "xattrs": {string : [bytes...] ...} | null,
+  "xattrs": {string : string | [bytes...] ...} | null,
   "sparse": boolean,
   "data_hash": "$KIND[:$HEXBYTE]" | null
 }

--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -221,6 +221,13 @@ pub fn anon_temp_file() -> Result<std::fs::File, std::io::Error> {
     Ok(f)
 }
 
+// Join two paths exactly as they are without any normalization.
+pub fn path_raw_join(l: &Path, r: &Path) -> PathBuf {
+    let mut p = l.to_owned().into_os_string();
+    p.push(r.as_os_str());
+    PathBuf::from(p)
+}
+
 // Get an absolute path without resolving symlinks or touching the fs.
 pub fn absolute_path<P>(path: P) -> std::io::Result<PathBuf>
 where

--- a/src/main.rs
+++ b/src/main.rs
@@ -1374,8 +1374,8 @@ fn get_main(args: Vec<String>) -> Result<(), anyhow::Error> {
         progress.set_message("picking content...");
 
         if let Some(ref index) = get_index {
-            let (pick_index, pick_data_map) =
-                index::pick(&matches.opt_str("pick").unwrap(), index)?;
+            let pick_path: PathBuf = matches.opt_str("pick").unwrap().into();
+            let (pick_index, pick_data_map) = index::pick(&pick_path, index)?;
             get_index = pick_index;
             get_data_map = Some(pick_data_map);
         } else {
@@ -1558,8 +1558,8 @@ fn list_contents_main(args: Vec<String>) -> Result<(), anyhow::Error> {
 
     if matches.opt_present("pick") {
         progress.set_message("picking content...");
-        content_index =
-            index::pick_dir_without_data(&matches.opt_str("pick").unwrap(), &content_index)?;
+        let pick_path: PathBuf = matches.opt_str("pick").unwrap().into();
+        content_index = index::pick_dir_without_data(&pick_path, &content_index)?;
     }
 
     client::hangup(&mut serve_in)?;
@@ -1859,8 +1859,8 @@ fn diff_main(args: Vec<String>) -> Result<(), anyhow::Error> {
     for (i, pick_opt) in ["left-pick", "right-pick"].iter().enumerate() {
         if matches.opt_present(pick_opt) {
             progress.set_message("picking content...");
-            to_diff[i] =
-                index::pick_dir_without_data(&matches.opt_str(pick_opt).unwrap(), &to_diff[i])?;
+            let pick_path: PathBuf = matches.opt_str(pick_opt).unwrap().into();
+            to_diff[i] = index::pick_dir_without_data(&pick_path, &to_diff[i])?;
         }
     }
 
@@ -2400,7 +2400,7 @@ fn restore_main(args: Vec<String>) -> Result<(), anyhow::Error> {
             restore_xattrs: matches.opt_present("xattrs"),
         },
         content_index,
-        matches.opt_str("pick"),
+        matches.opt_str("pick").map(|x| x.into()),
         &mut serve_out,
         &mut serve_in,
         &into_dir,

--- a/support/shell.nix
+++ b/support/shell.nix
@@ -7,7 +7,22 @@ in
       LIBCLANG_PATH="${pkgs.llvmPackages.libclang}/lib";
 
       buildInputs =  with pkgs; [ 
-        clang clang-tools llvm minio minio-client pandoc bats openssl libsodium pkg-config sqlite rust-bindgen jq ronn hyperfine
+        clang
+        clang-tools
+        llvm
+        entr
+        minio
+        minio-client
+        pandoc
+        bats
+        openssl
+        libsodium
+        pkg-config
+        sqlite
+        rust-bindgen
+        jq
+        ronn
+        hyperfine
       ];
 
       hardeningDisable = ["all"];


### PR DESCRIPTION
Move some core types from String to PathBuf in a backwards
compatible way. This change also tweaks the list-contents jsonl
output so that non utf8 strings are returned as a byte array.