### PR TITLE
Use libc::off_t type for NUM_PREFETCHED_BYTES

### DIFF
--- a/src/fprefetch.rs
+++ b/src/fprefetch.rs
@@ -20,7 +20,7 @@ cfg_if::cfg_if! {
       // Nothing is needed.
     } else {
       use std::os::unix::io::AsRawFd;
-      const NUM_PREFETCHED_BYTES: i64 = 128 * 1024 * 1024;
+      const NUM_PREFETCHED_BYTES: libc::off_t = 128 * 1024 * 1024;
     }
 }
 


### PR DESCRIPTION
I tried to compile bupstash on 32-bit arm, but it failed. This patch makes the compilation succeed.