### PR TITLE
Reduce the size of xattr encoding.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -22,6 +22,7 @@ use itertools::Itertools;
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
+use std::ffi::OsStr;
 use std::fmt::Write as FmtWrite;
 use std::io::{Read, Seek, Write};
 use std::os::unix::ffi::OsStrExt;
@@ -387,7 +388,7 @@ impl<'a, 'b, 'c> SendSession<'a, 'b, 'c> {
                         )?;
                         index_ent.data_hash = cache_entry.hashes[i];
                         index_ent.data_cursor = cache_entry.data_cursors[i];
-                        self.write_idx_ent(&index::VersionedIndexEntry::V4(index_ent))?;
+                        self.write_idx_ent(&index::VersionedIndexEntry::V5(index_ent))?;
                     }
                 }
                 None => {
@@ -499,7 +500,7 @@ impl<'a, 'b, 'c> SendSession<'a, 'b, 'c> {
                             content_hashes.push(index_ent.data_hash)
                         }
 
-                        self.write_idx_ent(&index::VersionedIndexEntry::V4(index_ent))?;
+                        self.write_idx_ent(&index::VersionedIndexEntry::V5(index_ent))?;
                     }
 
                     if self.send_log_session.is_some() && use_stat_cache && !smear_detected {
@@ -1726,11 +1727,11 @@ pub fn restore_to_local_dir(
             }
             if let Some(ref xattrs) = ent.xattrs {
                 for (attr, value) in xattrs.iter() {
-                    match xattr::set(to_ch, attr, value) {
+                    match xattr::set(to_ch, OsStr::from_bytes(attr), value) {
                         Ok(()) => (),
                         Err(err) => anyhow::bail!(
                             "failed to list remove xattr {} from {}: {}",
-                            attr.to_string_lossy(),
+                            String::from_utf8_lossy(attr),
                             to_ch.display(),
                             err
                         ),

--- a/src/fmtutil.rs
+++ b/src/fmtutil.rs
@@ -169,7 +169,7 @@ pub fn format_jsonl1_content_listing(ent: &index::IndexEntry) -> Result<String, 
         result.push_str(",\"xattrs\":{");
         let mut first = true;
         for (k, v) in xattrs.iter() {
-            let k = if let Some(k) = k.to_str() {
+            let k = if let Ok(k) = std::str::from_utf8(k) {
                 serde_json::to_string(k)?
             } else {
                 serde_json::to_string(k)?

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,5 +1,6 @@
 use super::fsutil;
 use super::index;
+use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::FileTypeExt;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::PermissionsExt;
@@ -114,7 +115,7 @@ fn get_metadata(path: &Path, opts: &FsMetadataFetcherOptions) -> std::io::Result
                             }
                             match xattrs {
                                 Some(ref mut xattrs) => {
-                                    xattrs.insert(attr, value);
+                                    xattrs.insert(attr.into_vec(), value);
                                 }
                                 _ => unreachable!(),
                             }

--- a/src/xtar.rs
+++ b/src/xtar.rs
@@ -121,7 +121,7 @@ pub fn index_entry_to_tarheader(
             for (k, v) in xattrs.iter() {
                 key_bytes.truncate(0);
                 key_bytes.extend_from_slice(b"SCHILY.xattr.");
-                key_bytes.extend_from_slice(k.as_bytes());
+                key_bytes.extend_from_slice(k);
                 pax_ext_records.extend_from_slice(&format_pax_extended_record(&key_bytes, v));
             }
         }


### PR DESCRIPTION
Serde inserts an extra byte for OsString types, this
changes the key type to Vec<u8> to avoid that.