### PR TITLE
Swap to a new faster rolling hash algorithm.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ panic = 'abort'
 codegen-units = 1
 incremental = false
 
+[features]
+simd-rollsum = []
+
 [dependencies]
 
 # More trusted dependencies

--- a/doc/upcoming_changelog.md
+++ b/doc/upcoming_changelog.md
@@ -1,54 +1,23 @@
-# Bupstash v0.11.1
-
-This release is a primarily a bug fix and maintenance release in preparation
-for an upcoming bupstash 1.0 release. While this release tweaks the repository
-format, the network protocol remains unchanged and interoperable.
+# Bupstash v0.11.2
 
 ## New features
 
-- Added a new --ignore-permission-errors option to `bupstash put`.
-- Added a new advanced environment variable BUPSTASH_KEEP_WAL=1 for 
- 'bupstash serve' (See WAL section below).
+- The deduplication rolling hash algorithm has been improved and is now faster 30 to 50 percent faster.
+  Those willing to compile bupstash from source using an unstable rust compiler will also gain access to SIMD (even faster) implementations of the algorithms.
 
 ## Notable Bug fixes
 
-- Fixed some cases where non utf8 paths caused bupstash to reject files.
-- Fixed a bug that caused using --pick on directories larger 15-20GiB to fail.
-
 ## Incompatibilities
 
-- The repository format has changed, repositories will be automatically migrated
-  by bupstash and cannot be used with older versions of bupstash after migration
-  (access across the network is still compatible).
-- Bupstash now performs upload checkpoints based on elapsed time instead of upload byte count.
-- BUPSTASH_CHECKPOINT_BYTES has been replaced by BUPSTASH_CHECKPOINT_SECONDS.
-
-## WAL
-
-Bupstash now writes all changes it makes to the repository to a WAL (write ahead log)
-file for crash recovery purposes. If the 'bupstash serve' command is run with the new
-BUPSTASH_KEEP_WAL=1 environment variable set, then WAL entries are accumulated in the
-repository `wal` directory instead of being removed when they are no longer needed.
-
-The main purpose of the wal directory is incremental replication of the repository
-metadata and history. Future bupstash versions may include tools to interact with
-these WAL files to do operations like point in time recovery or recovery from external storage engines.
-
-For now this feature is only for advanced users with specialist use cases.
-
-## Signed releases
-
-From this point on git tags and downloads will be signed by a gpg key from developers at the
-bupstash.io domain. The PGP signing keys can be found at https://bupstash.io/doc/man/bupstash-authors.html
-or via the source code repository itself in the file `doc/man/bupstash-authors.7.md`.
+- It is likely your repositories will temporarily grow in size if they contain data chunks from previous
+  versions of bupstash. This is because the new version of bupstash will map the same data to a different set
+  of chunks. If this is a problem for you, it be solved by cycling older data out over time, or
+  recreating your backups.
 
 ## Supporting bupstash
 
-Bupstash.io managed repositories now are in open beta and anyone can create an account.
+Bupstash.io managed repositories are in open beta and anyone can create an account.
 If you enjoy bupstash then please consider creating a managed repository at https://bupstash.io/managed.html
 to support the project.
-
-One handy way of using bupstash.io is in conjunction with `bupstash sync` and an external drive to
-keep a local and remote copy of your backups for extra assurance.
 
 Another great way to help the project is to just tell your friends to give bupstash a try.

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -1,8 +1,7 @@
-use super::rollsum::{GearTab, Rollsum, WINDOW_SIZE};
+use super::rollsum::{FastGearHasher, GearTab, RollsumSplitter};
 
 pub struct RollsumChunker {
-    gear_tab: GearTab,
-    rs: Rollsum,
+    rs: FastGearHasher,
     min_sz: usize,
     max_sz: usize,
     default_chunk_capacity: usize,
@@ -19,8 +18,7 @@ impl RollsumChunker {
         }
         let default_chunk_capacity = max_sz / 2;
         RollsumChunker {
-            rs: Rollsum::new(),
-            gear_tab,
+            rs: FastGearHasher::new(gear_tab),
             min_sz,
             max_sz,
             default_chunk_capacity,
@@ -39,44 +37,42 @@ impl RollsumChunker {
     }
 
     pub fn add_bytes(&mut self, buf: &[u8]) -> (usize, Option<Vec<u8>>) {
-        debug_assert!(self.cur_vec.len() < self.max_sz);
-
         let mut n_bytes = buf.len();
 
         if (n_bytes + self.cur_vec.len()) > self.max_sz {
             let overshoot = (n_bytes + self.cur_vec.len()) - self.max_sz;
             n_bytes -= overshoot;
-            debug_assert!(self.cur_vec.len() + n_bytes <= self.max_sz);
         }
 
         if self.spare_capacity() < n_bytes {
-            let mut growth = self.max_sz / 3;
-            if growth == 0 {
-                growth = 1;
-            }
+            let mut growth = (self.max_sz / 3).max(1);
             if self.cur_vec.capacity() + growth > self.max_sz {
                 growth = self.max_sz - self.cur_vec.capacity();
             }
             self.cur_vec.reserve(growth);
-            debug_assert!(self.spare_capacity() >= n_bytes);
+            n_bytes = std::cmp::min(self.spare_capacity(), n_bytes);
         }
 
         // None of the bytes we are adding will count towards the
         // next chunk, simply add them all, the bytes don't matter
         // as we will cycle WINDOW_SIZE too.
-        if self.min_sz >= WINDOW_SIZE
-            && (self.cur_vec.len() + n_bytes < (self.min_sz - WINDOW_SIZE))
-        {
-            self.cur_vec.extend_from_slice(&buf[0..n_bytes]);
-            return (n_bytes, None);
+        if let Some(window_size) = self.rs.window_size() {
+            if self.min_sz >= window_size
+                && (self.cur_vec.len() + n_bytes < (self.min_sz - window_size))
+            {
+                self.cur_vec.extend_from_slice(&buf[0..n_bytes]);
+                return (n_bytes, None);
+            }
         }
 
-        n_bytes = std::cmp::min(self.spare_capacity(), n_bytes);
-
-        match self.rs.roll_bytes(&self.gear_tab, &buf[0..n_bytes]) {
+        match self.rs.roll_bytes(&buf[0..n_bytes]) {
             Some(split) => {
                 self.cur_vec.extend_from_slice(&buf[0..split]);
-                (split, Some(self.swap_vec()))
+                if self.cur_vec.len() < self.min_sz {
+                    (split, None)
+                } else {
+                    (split, Some(self.swap_vec()))
+                }
             }
             None => {
                 self.cur_vec.extend_from_slice(&buf[0..n_bytes]);
@@ -116,12 +112,12 @@ impl RollsumChunker {
 
 #[cfg(test)]
 mod tests {
-    use super::super::rollsum::TEST_GEAR_TAB;
+    use super::super::rollsum::{GearTab, TEST_GEAR_TAB_DATA};
     use super::*;
 
     #[test]
     fn test_add_bytes() {
-        let mut ch = RollsumChunker::new(TEST_GEAR_TAB, 1, 2);
+        let mut ch = RollsumChunker::new(GearTab::from_array(TEST_GEAR_TAB_DATA), 1, 2);
 
         match ch.add_bytes(b"a") {
             (1, None) => (),
@@ -143,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_force_split_bytes() {
-        let mut ch = RollsumChunker::new(TEST_GEAR_TAB, 10, 100);
+        let mut ch = RollsumChunker::new(GearTab::from_array(TEST_GEAR_TAB_DATA), 10, 100);
         assert_eq!(ch.force_split(), None);
         ch.add_bytes(b"abc");
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,7 +33,7 @@ use std::rc::Rc;
 
 // These chunk parameters could be investigated and tuned.
 
-pub const CHUNK_MIN_SIZE: usize = 256 * 1024;
+pub const CHUNK_MIN_SIZE: usize = 32 * 1024;
 pub const CHUNK_MAX_SIZE: usize = 8 * 1024 * 1024;
 
 #[derive(Debug, thiserror::Error)]
@@ -689,9 +689,9 @@ pub fn send(
         added_bytes: 0,
         send_log_session: &mut send_log_session,
         acache: acache::ACache::new(32768),
-        data_chunker: chunker::RollsumChunker::new(ctx.gear_tab, min_size, max_size),
+        data_chunker: chunker::RollsumChunker::new(ctx.gear_tab.clone(), min_size, max_size),
         data_tw: Cell::new(Some(Box::new(htree::TreeWriter::new(min_size, max_size)))),
-        idx_chunker: chunker::RollsumChunker::new(ctx.gear_tab, min_size, max_size),
+        idx_chunker: chunker::RollsumChunker::new(ctx.gear_tab.clone(), min_size, max_size),
         idx_tw: Cell::new(Some(Box::new(htree::TreeWriter::new(min_size, max_size)))),
         idx_size: 0,
         data_size: 0,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -396,35 +396,35 @@ impl Drop for HashKey {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-pub struct RollsumKey {
+pub struct GearHashKey {
     pub bytes: [u8; RANDOM_SEED_BYTES],
 }
 
-impl RollsumKey {
+impl GearHashKey {
     pub fn new() -> Self {
         let mut bytes = [0; RANDOM_SEED_BYTES];
         randombytes(&mut bytes[..]);
-        RollsumKey { bytes }
+        GearHashKey { bytes }
     }
 
     pub fn gear_tab(&self) -> rollsum::GearTab {
-        let mut tab_bytes = [0; 256 * (rollsum::WINDOW_SIZE / 8)];
+        let mut tab_bytes = [0; 256 * 4];
         randombytes_buf_deterministic(&self.bytes, &mut tab_bytes[..]);
         let mut tab = [0; 256];
-        for (i, sl) in tab_bytes.chunks(rollsum::WINDOW_SIZE / 8).enumerate() {
+        for (i, sl) in tab_bytes.chunks(4).enumerate() {
             tab[i] = u32::from_le_bytes(sl.try_into().unwrap());
         }
-        tab
+        rollsum::GearTab::from_array(tab)
     }
 }
 
-impl Default for RollsumKey {
+impl Default for GearHashKey {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Drop for RollsumKey {
+impl Drop for GearHashKey {
     fn drop(&mut self) {
         memzero(&mut self.bytes[..]);
     }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -10,7 +10,7 @@ use std::os::unix::fs::OpenOptionsExt;
 pub struct PrimaryKey {
     pub id: Xid,
     /* key used to make the rollsum unique to this key. */
-    pub rollsum_key: crypto::RollsumKey,
+    pub rollsum_key: crypto::GearHashKey,
     /*
        Hash keys are used for content addressing, similar
        to git, but with an HMAC. This means plaintext
@@ -47,7 +47,7 @@ pub struct PrimaryKey {
 pub struct SubKey {
     pub id: Xid,
     pub primary_key_id: Xid,
-    pub rollsum_key: Option<crypto::RollsumKey>,
+    pub rollsum_key: Option<crypto::GearHashKey>,
     pub data_hash_key_part_1: Option<crypto::PartialHashKey>,
     pub data_hash_key_part_2: Option<crypto::PartialHashKey>,
     pub data_pk: Option<crypto::BoxPublicKey>,
@@ -224,7 +224,7 @@ impl Key {
 impl PrimaryKey {
     pub fn gen() -> PrimaryKey {
         let id = Xid::new();
-        let rollsum_key = crypto::RollsumKey::new();
+        let rollsum_key = crypto::GearHashKey::new();
         let data_hash_key_part_1 = crypto::PartialHashKey::new();
         let data_hash_key_part_2 = crypto::PartialHashKey::new();
         let (data_pk, data_sk) = crypto::box_keypair();
@@ -262,7 +262,7 @@ impl SubKey {
             primary_key_id: k.id,
 
             rollsum_key: if put {
-                Some(crypto::RollsumKey::new())
+                Some(crypto::GearHashKey::new())
             } else {
                 None
             },


### PR DESCRIPTION
This implements an entirely new rolling hash algorithm which we have called 'interleaved gear hash'. As far as we are aware the algorithm was invented by Quentin Carbonneaux and is currently unpublished. The change also includes SIMD implementations of these hash functions, although they currently require nightly rust to use.

Benchmarks:
```
Time to hash 5 GiB

export PATH="$PWD/target/release:$PATH"

export data="dd if=/dev/zero bs=1M obs=1M count=$((5*1024))"

hyperfine \
  --warmup 1 \
  "\$data | bupstash rollsum-benchmark 'GearHasher'" \
  "\$data | bupstash rollsum-benchmark 'InterleavedGearHasher<2>'" \
  "\$data | bupstash rollsum-benchmark 'InterleavedGearHasher<4>'" \
  "\$data | bupstash rollsum-benchmark 'InterleavedGearHasher<8>'" \
  "\$data | bupstash rollsum-benchmark 'InterleavedGearHasher<16>'" \
  "\$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<2>'" \
  "\$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<4>'" \
  "\$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<8>'" \
  "\$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<16>'"

# M1 Mac

Benchmark 1: $data | bupstash rollsum-benchmark 'GearHasher'
  Time (mean ± σ):      3.986 s ±  0.013 s    [User: 3.569 s, System: 0.758 s]
  Range (min … max):    3.961 s …  4.007 s    10 runs

Benchmark 2: $data | bupstash rollsum-benchmark 'InterleavedGearHasher<2>'
  Time (mean ± σ):      2.990 s ±  0.039 s    [User: 2.289 s, System: 0.823 s]
  Range (min … max):    2.938 s …  3.064 s    10 runs

Benchmark 3: $data | bupstash rollsum-benchmark 'InterleavedGearHasher<4>'
  Time (mean ± σ):      2.481 s ±  0.048 s    [User: 1.798 s, System: 0.786 s]
  Range (min … max):    2.382 s …  2.568 s    10 runs

Benchmark 4: $data | bupstash rollsum-benchmark 'InterleavedGearHasher<8>'
  Time (mean ± σ):      2.461 s ±  0.021 s    [User: 1.767 s, System: 0.799 s]
  Range (min … max):    2.426 s …  2.505 s    10 runs

Benchmark 5: $data | bupstash rollsum-benchmark 'InterleavedGearHasher<16>'
  Time (mean ± σ):      3.138 s ±  0.142 s    [User: 2.283 s, System: 0.882 s]
  Range (min … max):    2.939 s …  3.361 s    10 runs

Benchmark 6: $data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<2>'
  Time (mean ± σ):      4.198 s ±  0.036 s    [User: 3.751 s, System: 0.821 s]
  Range (min … max):    4.158 s …  4.270 s    10 runs

Benchmark 7: $data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<4>'
  Time (mean ± σ):      2.570 s ±  0.053 s    [User: 1.893 s, System: 0.801 s]
  Range (min … max):    2.506 s …  2.667 s    10 runs

Benchmark 8: $data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<8>'
  Time (mean ± σ):      2.075 s ±  0.107 s    [User: 1.409 s, System: 0.791 s]
  Range (min … max):    1.872 s …  2.239 s    10 runs

Benchmark 9: $data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<16>'
  Time (mean ± σ):      2.066 s ±  0.110 s    [User: 1.392 s, System: 0.793 s]
  Range (min … max):    1.837 s …  2.243 s    10 runs

Summary
  '$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<16>'' ran
    1.00 ± 0.07 times faster than '$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<8>''
    1.19 ± 0.06 times faster than '$data | bupstash rollsum-benchmark 'InterleavedGearHasher<8>''
    1.20 ± 0.07 times faster than '$data | bupstash rollsum-benchmark 'InterleavedGearHasher<4>''
    1.24 ± 0.07 times faster than '$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<4>''
    1.45 ± 0.08 times faster than '$data | bupstash rollsum-benchmark 'InterleavedGearHasher<2>''
    1.52 ± 0.11 times faster than '$data | bupstash rollsum-benchmark 'InterleavedGearHasher<16>''
    1.93 ± 0.10 times faster than '$data | bupstash rollsum-benchmark 'GearHasher''
    2.03 ± 0.11 times faster than '$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<2>''

# AMD Ryzen

Benchmark 1: $data | bupstash rollsum-benchmark 'GearHasher'
  Time (mean ± σ):      3.735 s ±  0.042 s    [User: 2.869 s, System: 2.161 s]
  Range (min … max):    3.682 s …  3.802 s    10 runs

Benchmark 2: $data | bupstash rollsum-benchmark 'InterleavedGearHasher<2>'
  Time (mean ± σ):      4.197 s ±  0.050 s    [User: 3.392 s, System: 2.177 s]
  Range (min … max):    4.103 s …  4.253 s    10 runs

Benchmark 3: $data | bupstash rollsum-benchmark 'InterleavedGearHasher<4>'
  Time (mean ± σ):      3.225 s ±  0.067 s    [User: 2.297 s, System: 2.142 s]
  Range (min … max):    3.052 s …  3.287 s    10 runs

Benchmark 4: $data | bupstash rollsum-benchmark 'InterleavedGearHasher<8>'
  Time (mean ± σ):      3.718 s ±  1.900 s    [User: 2.812 s, System: 2.143 s]
  Range (min … max):    3.075 s …  9.125 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 5: $data | bupstash rollsum-benchmark 'InterleavedGearHasher<16>'
  Time (mean ± σ):      4.044 s ±  0.044 s    [User: 3.235 s, System: 2.154 s]
  Range (min … max):    4.005 s …  4.154 s    10 runs

Benchmark 6: $data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<2>'
  Time (mean ± σ):      3.194 s ±  0.064 s    [User: 2.263 s, System: 2.152 s]
  Range (min … max):    3.061 s …  3.270 s    10 runs

Benchmark 7: $data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<4>'
  Time (mean ± σ):      2.711 s ±  0.009 s    [User: 1.684 s, System: 2.189 s]
  Range (min … max):    2.696 s …  2.725 s    10 runs

Benchmark 8: $data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<8>'
  Time (mean ± σ):      2.722 s ±  0.063 s    [User: 1.714 s, System: 2.166 s]
  Range (min … max):    2.567 s …  2.799 s    10 runs

Benchmark 9: $data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<16>'
  Time (mean ± σ):      2.737 s ±  0.029 s    [User: 1.722 s, System: 2.179 s]
  Range (min … max):    2.702 s …  2.783 s    10 runs

Summary
  '$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<4>'' ran
    1.00 ± 0.02 times faster than '$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<8>''
    1.01 ± 0.01 times faster than '$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<16>''
    1.18 ± 0.02 times faster than '$data | bupstash rollsum-benchmark 'SimdInterleavedGearHasher<2>''
    1.19 ± 0.03 times faster than '$data | bupstash rollsum-benchmark 'InterleavedGearHasher<4>''
    1.37 ± 0.70 times faster than '$data | bupstash rollsum-benchmark 'InterleavedGearHasher<8>''
    1.38 ± 0.02 times faster than '$data | bupstash rollsum-benchmark 'GearHasher''
    1.49 ± 0.02 times faster than '$data | bupstash rollsum-benchmark 'InterleavedGearHasher<16>''
    1.55 ± 0.02 times faster than '$data | bupstash rollsum-benchmark 'InterleavedGearHasher<2>''
```