### PR TITLE
cli-tests: Avoid path separator in names

### DIFF
--- a/cli-tests/cli-tests.bats
+++ b/cli-tests/cli-tests.bats
@@ -51,21 +51,21 @@ teardown () {
   rm -rf "$SCRATCH"
 }
 
-@test "simple put/get primary key" {
+@test "simple put+get primary key" {
   data="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   echo -n "$data" > "$SCRATCH/foo.txt"
   id="$(bupstash put :: "$SCRATCH/foo.txt")"
   test "$data" = "$(bupstash get id=$id )"
 }
 
-@test "simple put/get put key" {
+@test "simple put+get put key" {
   data="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   echo -n "$data" > "$SCRATCH/foo.txt"
   id="$(bupstash put -k "$PUT_KEY" :: "$SCRATCH/foo.txt")"
   test "$data" = "$(bupstash get id=$id )"
 }
 
-@test "simple put/get no compression" {
+@test "simple put+get no compression" {
   data="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   echo -n "$data" > "$SCRATCH/foo.txt"
   id="$(bupstash put --compression=none -k "$PUT_KEY" :: "$SCRATCH/foo.txt")"


### PR DESCRIPTION
bats(1) `--gather-test-outputs-in <directory>` is not happy with test
names, i.e. files names, containing `/`.

Found by making OpenBSD's port run the cli tests using at least
`--verbose --gather-test-outputs-in some/dir/`:
```
$ make test
...
ok 1 simple put/get primary key in 0ms
cp: /usr/ports/pobj/bupstash-0.12.0/build-amd64/test-results//1-simple put/get primary key.log: No such file or directory
ok 2 simple put/get put key in 0ms
cp: /usr/ports/pobj/bupstash-0.12.0/build-amd64/test-results//2-simple put/get put key.log: No such file or directory
ok 3 simple put/get no compression in 1000ms
cp: /usr/ports/pobj/bupstash-0.12.0/build-amd64/test-results//3-simple put/get no compression.log: No such file or directory
ok 4 put name override in 0ms
ok 5 random data in 5000ms
...
```

Use `+` instead;  purely cosmetic, anyway.
