### PR TITLE
Add a Cross.toml file and a note on using it

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,6 @@
+[target.x86_64-unknown-linux-musl]
+image="rust:1.68-alpine"
+pre-build = [
+  "apk update && apk upgrade",
+  "apk add lz4-dev libsodium-dev libsodium-static libc-dev"
+]

--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ $ cargo build --release
 $ cp ./target/release/bupstash $INSTALL_DIR
 ```
 
+If you need a statically linked `musl` build for e.g. your NAS box, you can do
+this with [cross](https://github.com/cross-rs/cross). (You also need Docker
+installed and working).
+
+```sh
+$ cargo install cross --git https://github.com/cross-rs/cross
+$ cross build --target x86_64-unknown-linux-musl --release
+```
+
 ### Pkgconf
 
 You can use pkgconf instead of pkg-config (this is required on freebsd) by setting


### PR DESCRIPTION
This provides a statically linked build that will work on musl-based
Linuxes such as those commonly used on NAS boxes.
#