### PR TITLE
Disable unused/unnecessary regex features to reduce binary size.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ humantime = "2.0.1"
 atty = "0.2"
 once_cell = "1.4"
 tar = "0.4"
-regex = "1"
+regex = { version = "1", default-features = false, features = ["std"] }
 globset = "0.4.8"
 chrono = { version = "0.4", features = ["serde"]}
 cfg-if = "0.1"


### PR DESCRIPTION
This reduces the size of the bupstash binary by ~400 kiB.