### PR TITLE
Fix broken Rust test suite and clippy warnings.

### DIFF
--- a/src/fstx2.rs
+++ b/src/fstx2.rs
@@ -799,8 +799,8 @@ mod tests {
         let txn = ReadTxn::begin_at(&fs).unwrap();
         assert_eq!(txn.read("append").unwrap(), vec![1, 2, 3]);
         assert_eq!(txn.read("write").unwrap(), vec![4, 5, 6]);
-        assert!(txn.metadata("renamed").is_ok());
-        assert!(txn.metadata("some_dir").is_ok());
+        assert!(txn.fs.metadata("renamed").is_ok());
+        assert!(txn.fs.metadata("some_dir").is_ok());
         txn.end();
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -55,11 +55,7 @@ pub enum Query {
 }
 
 fn is_tag_char(c: char) -> bool {
-    ('a'..='z').contains(&c)
-        || ('A'..='Z').contains(&c)
-        || ('0'..='9').contains(&c)
-        || c == '-'
-        || c == '_'
+    c.is_ascii_alphanumeric() || c == '-' || c == '_'
 }
 
 macro_rules! impl_binop {


### PR DESCRIPTION
Addresses the following errors:

## Cargo test

```
$ cargo test
   Compiling bupstash v0.12.1 (/home/ante/dev/bupstash)
error[E0599]: no method named `metadata` found for struct `fstx2::ReadTxn` in the current scope
   --> src/fstx2.rs:802:21
    |
307 | pub struct ReadTxn<'a> {
    | ---------------------- method `metadata` not found for this struct
...
802 |         assert!(txn.metadata("renamed").is_ok());
    |                     ^^^^^^^^ method not found in `ReadTxn<'_>`
    |
help: some of the expressions' fields have a method of the same name
    |
802 |         assert!(txn._lock.metadata("renamed").is_ok());
    |                     ++++++
802 |         assert!(txn.fs.metadata("renamed").is_ok());
    |                     +++

error[E0599]: no method named `metadata` found for struct `fstx2::ReadTxn` in the current scope
   --> src/fstx2.rs:803:21
    |
307 | pub struct ReadTxn<'a> {
    | ---------------------- method `metadata` not found for this struct
...
803 |         assert!(txn.metadata("some_dir").is_ok());
    |                     ^^^^^^^^ method not found in `ReadTxn<'_>`
    |
help: some of the expressions' fields have a method of the same name
    |
803 |         assert!(txn._lock.metadata("some_dir").is_ok());
    |                     ++++++
803 |         assert!(txn.fs.metadata("some_dir").is_ok());
    |                     +++

For more information about this error, try `rustc --explain E0599`.
error: could not compile `bupstash` (bin "bupstash" test) due to 2 previous errors
```

## Clippy
```
$ cargo clippy
    Checking bupstash v0.12.1 (/home/ante/dev/bupstash)
warning: manual check for common ascii range
  --> src/query.rs:58:5
   |
58 |     ('a'..='z').contains(&c)
   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `c.is_ascii_lowercase()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_ascii_check
   = note: `#[warn(clippy::manual_is_ascii_check)]` on by default

warning: manual check for common ascii range
  --> src/query.rs:59:12
   |
59 |         || ('A'..='Z').contains(&c)
   |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `c.is_ascii_uppercase()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_ascii_check

warning: manual check for common ascii range
  --> src/query.rs:60:12
   |
60 |         || ('0'..='9').contains(&c)
   |            ^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `c.is_ascii_digit()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_ascii_check

warning: `bupstash` (bin "bupstash") generated 3 warnings (run `cargo clippy --fix --bin "bupstash"` to apply 3 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 3.03s
```