### PR TITLE
Add space between brackets in doc to make precedence grouping example valid

### DIFF
--- a/doc/man/bupstash-query-language.7.md
+++ b/doc/man/bupstash-query-language.7.md
@@ -48,7 +48,7 @@ $ bupstash list hostname=server1 or hostname=server2
 
 Precedence grouping:
 ```
-$ bupstash list [hostname=server1 or hostname=server2] and date=2020-* 
+$ bupstash list [ hostname=server1 or hostname=server2 ] and date=2020-* 
 ...
 ```
 


### PR DESCRIPTION
The example query will lead to a query error, as the syntax is not valid.  `bupstash list [hostname=server1 or hostname=server2]` will fail, while `bupstash list [ hostname=server1 or hostname=server2 ]` will work.