### PR TITLE
Add NetBSD support.

### DIFF
--- a/src/fprefetch.rs
+++ b/src/fprefetch.rs
@@ -64,6 +64,8 @@ fn open_file_for_streaming(fpath: &std::path::Path) -> std::io::Result<File> {
             // Perhaps F_RDADVISE ?
         } else if #[cfg(target_os = "openbsd")] {
             // XXX can we do anything here?
+        } else if #[cfg(target_os = "netbsd")] {
+            // XXX can we do anything here?
         } else {
             // We would like to use something like POSIX_FADV_NOREUSE to preserve
             // the user page cache... this is actually a NOOP on linux.

--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -167,6 +167,20 @@ cfg_if::cfg_if! {
             (dev & 0xff) | ((dev & 0xffff0000) >> 8)
         }
 
+    } else if #[cfg(target_os = "netbsd")] {
+
+        pub fn makedev(major: u64, minor: u64) -> libc::dev_t {
+            (((major & 0xfff) << 8) | (minor & 0xff) | ((minor & 0xfff00) << 12)) as libc::dev_t
+        }
+
+        pub fn dev_major(dev: u64) -> u64 {
+            (dev >> 8) & 0xfff
+        }
+
+        pub fn dev_minor(dev :u64) -> u64 {
+            (dev & 0xff) | ((dev & 0xfff00000) >> 12)
+        }
+
      } else if #[cfg(target_os = "freebsd")] {
 
         // See https://github.com/freebsd/freebsd-src/sys/sys/types.h


### PR DESCRIPTION
Source for the bit shift and mask logic can be found in the NetBSD source tree, in [sys/sys/types.h](https://nxr.netbsd.org/xref/src/sys/sys/types.h#274).

Tested by creating and restoring a backup of /dev on NetBSD-9.3.